### PR TITLE
fix: udev permissions robustness + startup check (v1.0.14)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.14] - 8 April 2026
+
+### Added
+
+- **udev rules check at startup**: GUI shows a dialog at startup when udev rules are missing or invalid, with an "Install rules" button that runs the fix automatically (requires administrator password). The daemon also logs a warning on the same condition.
+
+### Fixed
+
+- **`sudo_it()` fallback**: now tries `sudo` if `pkexec` is unavailable or fails, and catches `CalledProcessError` instead of crashing.
+- **`write_udev_rules()` blocking `input()`**: removed interactive prompt that caused hangs in non-interactive installs (scripts, TTY-less environments).
+- **`write_udev_rules()` fragile `echo` escaping**: replaced shell `echo "..."` (broken on special chars like `!`, `$`) with a temp file + `cp` approach when writing with elevated privileges.
+- **`reload_udev_rules()` unhandled exception**: `CalledProcessError` from `udevadm` is now caught and reported cleanly.
+
 ## [1.0.13] - 4 April 2026
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.13"
+version = "1.0.14"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/arctis_sound_manager/gui/udev_dialog.py
+++ b/src/arctis_sound_manager/gui/udev_dialog.py
@@ -1,0 +1,106 @@
+"""
+UdevRulesDialog — shown at startup when udev rules are missing or invalid.
+"""
+import shutil
+import subprocess
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QDialog,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from arctis_sound_manager.gui.theme import (
+    ACCENT,
+    BG_BUTTON,
+    BG_BUTTON_HOVER,
+    BG_MAIN,
+    TEXT_PRIMARY,
+    TEXT_SECONDARY,
+)
+
+_BTN = (
+    "QPushButton {{ background-color: {bg}; color: {fg}; border: none; "
+    "border-radius: 6px; padding: 8px 18px; font-size: 10pt; }}"
+    "QPushButton:hover {{ background-color: {hover}; }}"
+)
+
+
+class UdevRulesDialog(QDialog):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle("USB permissions — Arctis Sound Manager")
+        self.setMinimumSize(520, 280)
+        self.setStyleSheet(f"background-color: {BG_MAIN}; color: {TEXT_PRIMARY};")
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(28, 28, 28, 20)
+        layout.setSpacing(14)
+
+        title_lbl = QLabel("USB device permissions not configured")
+        title_lbl.setStyleSheet(
+            f"color: {TEXT_PRIMARY}; font-size: 15pt; font-weight: bold; background: transparent;"
+        )
+        layout.addWidget(title_lbl)
+
+        sub_lbl = QLabel(
+            "The udev rules required to access your Arctis headset without root "
+            "privileges are missing or incomplete.\n\n"
+            "Without them, the daemon cannot open the USB device "
+            "(Error 13: Access denied).\n\n"
+            "Click \"Install rules\" to fix this automatically "
+            "(requires administrator password)."
+        )
+        sub_lbl.setStyleSheet(
+            f"color: {TEXT_SECONDARY}; font-size: 10pt; background: transparent;"
+        )
+        sub_lbl.setWordWrap(True)
+        layout.addWidget(sub_lbl, stretch=1)
+
+        self._status_lbl = QLabel("")
+        self._status_lbl.setStyleSheet(
+            f"color: {ACCENT}; font-size: 9pt; background: transparent;"
+        )
+        self._status_lbl.setWordWrap(True)
+        layout.addWidget(self._status_lbl)
+
+        btn_row = QHBoxLayout()
+        btn_row.setSpacing(10)
+        btn_row.addStretch()
+
+        ignore_btn = QPushButton("Ignore")
+        ignore_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        ignore_btn.setStyleSheet(_BTN.format(bg=BG_BUTTON, fg=TEXT_PRIMARY, hover=BG_BUTTON_HOVER))
+        ignore_btn.clicked.connect(self.reject)
+        btn_row.addWidget(ignore_btn)
+
+        self._install_btn = QPushButton("Install rules")
+        self._install_btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        self._install_btn.setStyleSheet(_BTN.format(bg=ACCENT, fg="#ffffff", hover=BG_BUTTON_HOVER))
+        self._install_btn.clicked.connect(self._install)
+        btn_row.addWidget(self._install_btn)
+
+        layout.addLayout(btn_row)
+
+    def _install(self) -> None:
+        cli = shutil.which('asm-cli')
+        if not cli:
+            self._status_lbl.setText("asm-cli not found. Run: asm-cli udev write-rules --force --reload")
+            return
+
+        self._install_btn.setEnabled(False)
+        self._install_btn.setText("Installing...")
+
+        try:
+            subprocess.run(
+                [cli, 'udev', 'write-rules', '--force', '--reload'],
+                check=True,
+            )
+            self.accept()
+        except subprocess.CalledProcessError as e:
+            self._status_lbl.setText(f"Installation failed (code {e.returncode}). Try: sudo asm-cli udev write-rules --force --reload")
+            self._install_btn.setEnabled(True)
+            self._install_btn.setText("Install rules")

--- a/src/arctis_sound_manager/scripts/cli.py
+++ b/src/arctis_sound_manager/scripts/cli.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
+import tempfile
 from argparse import ArgumentParser
 from pathlib import Path
 from typing import NamedTuple
@@ -30,14 +31,20 @@ DESKTOP_WINDOW_PATH = APPLICATIONS_PATH / 'ArctisManager.desktop'
 DESKTOP_SYSTRAY_PATH = APPLICATIONS_PATH / 'ArctisManagerSystray.desktop'
 
 def sudo_it(command: list[str]) -> int:
-    pkexec = shutil.which('pkexec')
-    if not pkexec:
-        print('pkexec not found.')
-        return 250
+    for elevator in ['pkexec', 'sudo']:
+        binary = shutil.which(elevator)
+        if not binary:
+            continue
+        try:
+            result = subprocess.run([binary, *command], check=True)
+            return result.returncode
+        except subprocess.CalledProcessError as e:
+            print(f'{elevator} failed with code {e.returncode}.')
+        except FileNotFoundError:
+            pass
 
-    result = subprocess.run(["pkexec", *command], check=True)
-
-    return result.returncode
+    print('No privilege escalation tool found (pkexec or sudo).')
+    return 250
 
 def write_udev_rules(rules_path: Path, create_directories: bool, force_write: bool) -> int:
     run_with_sudo = False
@@ -61,12 +68,7 @@ def write_udev_rules(rules_path: Path, create_directories: bool, force_write: bo
 
     if rules_path.exists() and not os.access(rules_path, os.W_OK) \
         or not rules_path.exists() and not os.access(rules_path.parent, os.W_OK):
-        print('')
-        print(f"User can't write to {rules_path}.")
-        print('Command will be executed with pkexec (root).')
-        print('')
-        input('Press Enter to continue...')
-
+        print(f"User can't write to {rules_path}. Elevating privileges (pkexec or sudo)...")
         run_with_sudo = True
     
     if not force_write and rules_path.exists():
@@ -101,13 +103,17 @@ ACTION=="remove", GOTO="local_end"
 
 LABEL="local_end"'''
     if run_with_sudo:
-        escaped_file_content = file_content.replace('"', '\\"')
-        command = ["sh", "-c", f"echo \"{escaped_file_content}\" > \"{rules_path}\""]
-        return sudo_it(command)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.rules', delete=False) as tmp:
+            tmp.write(f'{file_content}\n')
+            tmp_path = tmp.name
+        try:
+            return sudo_it(["cp", tmp_path, str(rules_path)])
+        finally:
+            os.unlink(tmp_path)
     else:
         with rules_path.open('w') as f:
             f.write(f'{file_content}\n')
-    
+
     return 0
 
 def reload_udev_rules() -> int:
@@ -121,18 +127,19 @@ def reload_udev_rules() -> int:
         ('Trigger Rules', ["udevadm", "trigger", "--subsystem-match=usb"]),
     ]
     result = 0
-    for command in commands:
-        print(f'Phase: {command[0]}')
-        if run_with_sudo:
-            result = sudo_it(command[1])
-            if result:
-                print('- Process failed!')
-                return result
-        else:
-            result = subprocess.run(command[1], check=True).returncode
-            if result:
-                print('- Process failed!')
-                return result
+    for name, command in commands:
+        print(f'Phase: {name}')
+        try:
+            if run_with_sudo:
+                result = sudo_it(command)
+            else:
+                result = subprocess.run(command, check=True).returncode
+        except subprocess.CalledProcessError as e:
+            print(f'- Process failed with code {e.returncode}!')
+            return e.returncode
+        if result:
+            print('- Process failed!')
+            return result
 
     return result
 

--- a/src/arctis_sound_manager/scripts/daemon.py
+++ b/src/arctis_sound_manager/scripts/daemon.py
@@ -20,6 +20,10 @@ async def main_async():
     logger.info(f'-{"v " + project_version():>27}  -')
     logger.info('-------------------------------')
 
+    from arctis_sound_manager.udev_checker import is_udev_rules_valid
+    if not is_udev_rules_valid():
+        logger.warning('udev rules are missing or invalid — USB access may fail (errno 13). Run: sudo asm-cli udev write-rules --force --reload')
+
     dbus_manager = DbusManager.getInstance()
     core_engine = CoreEngine()
 

--- a/src/arctis_sound_manager/scripts/gui.py
+++ b/src/arctis_sound_manager/scripts/gui.py
@@ -84,6 +84,14 @@ def main():
             ReportBugDialog(traceback_str=crash.get('traceback'), is_crash=True).exec()
         QTimer.singleShot(1500, _show_crash)
 
+    # ── udev rules check ──────────────────────────────────────────────────────
+    from arctis_sound_manager.udev_checker import is_udev_rules_valid
+    if not is_udev_rules_valid():
+        from arctis_sound_manager.gui.udev_dialog import UdevRulesDialog
+        def _check_udev():
+            UdevRulesDialog().exec()
+        QTimer.singleShot(500, _check_udev)
+
     # Open the window once the event loop is running.
     if not args.systray:
         QTimer.singleShot(0, q_object.open_main_window)

--- a/src/arctis_sound_manager/udev_checker.py
+++ b/src/arctis_sound_manager/udev_checker.py
@@ -1,0 +1,16 @@
+from pathlib import Path
+
+from arctis_sound_manager.constants import UDEV_RULES_PATHS
+
+
+def is_udev_rules_valid() -> bool:
+    """Returns True if a valid ASM udev rules file exists on disk."""
+    for p in UDEV_RULES_PATHS:
+        path = Path(p)
+        if path.exists():
+            try:
+                content = path.read_text()
+                return '1038' in content and 'uaccess' in content
+            except OSError:
+                pass
+    return False


### PR DESCRIPTION
## Summary

- **Fixes #3** — `[Errno 13] Access denied` on USB device access
- `sudo_it()` now falls back to `sudo` if `pkexec` is unavailable or cancelled, and catches `CalledProcessError` instead of crashing
- `write_udev_rules()` removes the blocking `input()` that hung non-interactive installs, and replaces the fragile `echo` shell escaping with a temp file + `cp` approach
- `reload_udev_rules()` now catches `CalledProcessError` cleanly
- New `udev_checker.py` module with `is_udev_rules_valid()`
- New `gui/udev_dialog.py` — dialog shown at startup when rules are missing, with an **Install rules** button (auto-elevates via pkexec/sudo)
- Daemon logs a `WARNING` on startup if rules are missing

## Test plan

- [ ] Fresh install without udev rules → GUI shows the dialog at startup
- [ ] Click "Install rules" → rules written, dialog closes
- [ ] Click "Ignore" → dialog closes, app continues normally
- [ ] `asm-cli udev write-rules --force --reload` works without interactive prompt
- [ ] Works on systems with only `sudo` (no `pkexec`)
- [ ] `asm-daemon` logs warning when rules are absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)