### PR TITLE
fix: context-aware privilege elevation (v1.0.15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.15] - 8 April 2026
+
+### Fixed
+
+- **Context-aware privilege elevation** (`sudo_it`): the elevation tool is now chosen based on the execution context rather than tried blindly in a fixed order:
+  - **Terminal (TTY)** → `sudo` first (native prompt), then graphical tools as fallback
+  - **GUI / no TTY** → DE-specific graphical tools (`kdesu` on KDE, `lxqt-sudo` on LXQt) then `pkexec` — `sudo` is never attempted without a TTY
+  - **Headless / no display** → `sudo` only (service context, NOPASSWD sudoers)
+  - Prints an actionable hint when no tool is found in headless context
+
 ## [1.0.14] - 8 April 2026
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.14"
+version = "1.0.15"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/arctis_sound_manager/scripts/cli.py
+++ b/src/arctis_sound_manager/scripts/cli.py
@@ -30,8 +30,54 @@ APPLICATIONS_PATH = Path().home() / '.local' / 'share' / 'applications'
 DESKTOP_WINDOW_PATH = APPLICATIONS_PATH / 'ArctisManager.desktop'
 DESKTOP_SYSTRAY_PATH = APPLICATIONS_PATH / 'ArctisManagerSystray.desktop'
 
+def _has_tty() -> bool:
+    """Returns True if stdin is a real terminal (CLI context)."""
+    try:
+        return os.isatty(sys.stdin.fileno())
+    except Exception:
+        return False
+
+
+def _is_graphical() -> bool:
+    """Returns True if a graphical display server is available."""
+    return bool(os.environ.get('DISPLAY') or os.environ.get('WAYLAND_DISPLAY'))
+
+
+def _graphical_elevators() -> list[str]:
+    """
+    Returns an ordered list of graphical elevation tools for the current
+    desktop environment. pkexec (polkit) is the universal fallback.
+    """
+    desktop = os.environ.get('XDG_CURRENT_DESKTOP', '').lower()
+    tools: list[str] = []
+    if 'kde' in desktop:
+        tools += ['kdesu', 'kdesudo']
+    elif 'lxqt' in desktop:
+        tools += ['lxqt-sudo']
+    tools.append('pkexec')
+    return tools
+
+
 def sudo_it(command: list[str]) -> int:
-    for elevator in ['pkexec', 'sudo']:
+    """
+    Run *command* with elevated privileges, picking the right tool based on
+    the execution context:
+
+    - Terminal (TTY present)  → sudo first, graphical tools as fallback
+    - GUI (display, no TTY)   → graphical tools only (pkexec / DE-specific)
+    - Headless (no TTY/display) → sudo only (expects NOPASSWD or service context)
+    """
+    has_tty = _has_tty()
+    graphical = _is_graphical()
+
+    if has_tty:
+        elevators = ['sudo'] + _graphical_elevators()
+    elif graphical:
+        elevators = _graphical_elevators()
+    else:
+        elevators = ['sudo']
+
+    for elevator in elevators:
         binary = shutil.which(elevator)
         if not binary:
             continue
@@ -43,7 +89,9 @@ def sudo_it(command: list[str]) -> int:
         except FileNotFoundError:
             pass
 
-    print('No privilege escalation tool found (pkexec or sudo).')
+    print('No working privilege escalation tool found.')
+    if not has_tty and not graphical:
+        print('Hint: configure sudoers NOPASSWD or run manually: sudo asm-cli udev write-rules --force --reload')
     return 250
 
 def write_udev_rules(rules_path: Path, create_directories: bool, force_write: bool) -> int:


### PR DESCRIPTION
## Summary

Remplace la liste fixe `pkexec → sudo` par une détection du contexte d'exécution dans `sudo_it()`.

| Contexte | Outils tentés dans l'ordre |
|---|---|
| Terminal (TTY présent) | `sudo` → outils graphiques |
| GUI (display, pas de TTY) | `kdesu`/`lxqt-sudo` (si KDE/LXQt) → `pkexec` |
| Headless (pas de TTY, pas de display) | `sudo` uniquement |

**Avant** : `sudo` était toujours tenté depuis la GUI — sans TTY il échouait silencieusement.  
**Après** : depuis la GUI, `sudo` n'est jamais appelé, on passe directement aux outils graphiques adaptés à l'environnement.

## Test plan

- [ ] Terminal → `sudo` demande le mot de passe dans le terminal
- [ ] GUI GNOME/KDE/autre → `pkexec` ouvre la fenêtre graphique de mot de passe
- [ ] GUI KDE → `kdesu` est tenté en premier si disponible
- [ ] GUI LXQt → `lxqt-sudo` est tenté en premier si disponible
- [ ] Headless sans TTY/display → `sudo` uniquement, hint affiché si introuvable
- [ ] Aucun outil disponible → code retour 250 + message clair

🤖 Generated with [Claude Code](https://claude.com/claude-code)