### PR TITLE
fix: correct Nova Pro Wired transport and packet size (v1.0.17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.17] - 9 April 2026
+
+### Fixed
+
+- **Arctis Nova Pro Wired config** (`0x12cb` / `0x12cd`): corrected two issues found via hardware testing (`asm-cli tools arctis-devices`):
+  - `command_transport: ctrl_output` — device has no interrupt OUT endpoint, commands must be sent via HID SET_REPORT
+  - `command_padding.length: 16` — IN endpoint MaxPacketSize is 16 bytes (was incorrectly set to 64)
+
 ## [1.0.16] - 8 April 2026
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.16"
+version = "1.0.17"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/arctis_sound_manager/devices/arctis_nova_pro_wired.yaml
+++ b/src/arctis_sound_manager/devices/arctis_nova_pro_wired.yaml
@@ -5,12 +5,14 @@ device:
     - 0x12cb # Arctis Nova Pro Wired
     - 0x12cd # Arctis Nova Pro Wired (Xbox)
   command_padding:
-    length: 64
+    length: 16
     position: end
     filler: 0x00
 
-  # Interface 4 is the primary HID control interface on all Nova Pro variants.
-  # Protocol is shared between wired (0x12cb/0x12cd) and wireless (0x12e0/0x12e5).
+  # Interface 4 is the primary HID control interface (confirmed via asm-cli tools arctis-devices).
+  # No interrupt OUT endpoint present — commands are sent via HID SET_REPORT (ctrl_output).
+  # MaxPacketSize for IN endpoints is 16 bytes on both interface 3 and 4.
+  command_transport: ctrl_output
   command_interface_index: [4, 0]
   listen_interface_indexes: [4]
 


### PR DESCRIPTION
Fixes based on hardware output from `asm-cli tools arctis-devices` shared in #2:

```
SteelSeries Arctis Nova Pro (1038:12cb)
Configuration: 1
HID interface (num : alt): 3 : 0
Endpoint: 87 Dir=IN Type=Interrupt MaxPacketSize=16
HID interface (num : alt): 4 : 0
Endpoint: 88 Dir=IN Type=Interrupt MaxPacketSize=16
```

## Changes

**`command_transport: ctrl_output`**
No interrupt OUT endpoint is present on either interface. Commands must be sent via HID SET_REPORT (output type) rather than interrupt OUT. The previous config used the default `interrupt` transport which requires an OUT endpoint → device was unreachable.

**`command_padding.length: 16`**
IN endpoint MaxPacketSize is 16 bytes on both interfaces. The previous value of 64 (inherited from Nova Pro Wireless) was incorrect for this device.

## Test plan

- [ ] Device detected by daemon on plugin
- [ ] Sidetone setting applies
- [ ] Mic volume slider works
- [ ] Status responses received (mic mute indicator, volume events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)