### PR TITLE
fix: ppa-upload sed replaces full changelog first line

### DIFF
--- a/.github/workflows/ppa-upload.yaml
+++ b/.github/workflows/ppa-upload.yaml
@@ -39,8 +39,9 @@ jobs:
               print(tomllib.load(f)['project']['version'])
           ")
           SERIES="${{ matrix.series }}"
-          # Replace the first changelog entry's version and distribution
-          sed -i "1s/(.*)/(${VERSION}-1~${SERIES}1) ${SERIES}/" debian/changelog
+          # Replace the entire first line to avoid basic-regex pitfall where
+          # (.*) matches literal parens only, leaving the old series in place.
+          sed -i "1s|.*|arctis-sound-manager (${VERSION}-1~${SERIES}1) ${SERIES}; urgency=medium|" debian/changelog
 
       - name: Import GPG key
         run: |


### PR DESCRIPTION
## Problème

Launchpad rejetait les uploads avec :
```
Unable to find distroseries: oracular noble
arctis-sound-manager (1.0.17-1~oracular1) oracular noble; urgency=medium
```

## Cause

Le `sed` utilisait la regex `(.*)` en basic sed. En basic sed, les parenthèses sont **littérales** — `(.*)` correspond donc à `(1.0.13-1)` uniquement, pas à toute la ligne.

Résultat : seule la version était remplacée, mais ` noble; urgency=medium` restait en place, produisant `oracular noble` au lieu de `oracular`.

## Fix

Remplacer toute la première ligne avec `|.*|...|` (délimiteur `|` pour éviter les conflits avec `/`) :

```bash
# Avant
sed -i "1s/(.*)/(${VERSION}-1~${SERIES}1) ${SERIES}/" debian/changelog
# Après
sed -i "1s|.*|arctis-sound-manager (${VERSION}-1~${SERIES}1) ${SERIES}; urgency=medium|" debian/changelog
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)