### PR TITLE
fix: remove oracular from PPA upload matrix (EOL) — v1.0.19

### DIFF
--- a/.github/workflows/ppa-upload.yaml
+++ b/.github/workflows/ppa-upload.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        series: [noble, oracular]
+        series: [noble]
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.19] - 9 April 2026
+
+### Fixed
+
+- **PPA upload workflow**: removed `oracular` (Ubuntu 24.10, EOL since July 2025) from the target matrix — Launchpad no longer accepts uploads for this series. Only `noble` (24.04 LTS) is targeted.
+
 ## [1.0.18] - 9 April 2026
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.18"
+version = "1.0.19"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
`oracular` (Ubuntu 24.10) est EOL depuis juillet 2025. Launchpad refuse les uploads :
```
oracular is obsolete and will not accept new uploads.
```

Seul `noble` (24.04 LTS) est conservé dans la matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)