### PR TITLE
fix: include pre-built wheels in PPA source package (v1.0.20)

### DIFF
--- a/.github/workflows/ppa-upload.yaml
+++ b/.github/workflows/ppa-upload.yaml
@@ -51,7 +51,12 @@ jobs:
 
       - name: Build source package
         run: |
-          debuild -S -sa -d -k"$GPG_KEY_ID"
+          # --no-pre-clean prevents dpkg-buildpackage from running
+          # debian/rules clean before packaging the source — without it,
+          # debian/wheels/ is deleted before the .debian.tar.xz is created,
+          # so Launchpad receives a source package with no wheels and cannot
+          # download them (sandboxed build environment, no internet).
+          debuild -S -sa -d -k"$GPG_KEY_ID" -- --no-pre-clean
 
       - name: Upload to PPA
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.20] - 9 April 2026
+
+### Fixed
+
+- **PPA build failure** (`Failed to build` on Launchpad): `debuild -S` runs `debian/rules clean` before packaging the source, deleting `debian/wheels/` — Launchpad received a source package without wheels and couldn't download them (no internet in sandbox). Fixed by:
+  - Adding `--no-pre-clean` to `debuild -S` so wheels survive source packaging
+  - Removing `debian/wheels` from `override_dh_auto_clean` so Launchpad's pre-build clean doesn't destroy them either
+
 ## [1.0.19] - 9 April 2026
 
 ### Fixed

--- a/debian/rules
+++ b/debian/rules
@@ -74,4 +74,6 @@ override_dh_auto_test:
 	@true
 
 override_dh_auto_clean:
-	rm -rf dist build *.egg-info debian/wheels
+	rm -rf dist build *.egg-info
+	# debian/wheels is intentionally preserved — it contains pre-built wheels
+	# shipped inside the source package so Launchpad can build without internet.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.19"
+version = "1.0.20"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Cause racine

`debuild -S` appelle `debian/rules clean` **avant** de créer le `.debian.tar.xz`. Cela supprime `debian/wheels/`. Résultat : Launchpad reçoit une source sans wheels et tente de les télécharger depuis PyPI — impossible en sandbox.

## Corrections

**`ppa-upload.yaml`** — ajout de `-- --no-pre-clean` :
```bash
debuild -S -sa -d -k"$GPG_KEY_ID" -- --no-pre-clean
```
Les wheels survivent jusqu'à la création du paquet source.

**`debian/rules`** — suppression de `debian/wheels` de `override_dh_auto_clean` :
Le build Launchpad lance aussi `debian/rules clean` avant de compiler. Sans ce fix, les wheels seraient de nouveau supprimées côté Launchpad.

## Flux corrigé

```
CI (internet disponible)
  → build wheels → debian/wheels/
  → debuild -S --no-pre-clean → .debian.tar.xz contient debian/wheels/
  → upload Launchpad

Launchpad (pas d'internet)
  → extrait source (debian/wheels/ présent)
  → debian/rules clean → dist/build/egg-info supprimés, wheels préservés
  → debian/rules build → [ -d debian/wheels ] = true → utilise les wheels
  ✅
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)