### PR TITLE
fix: use dpkg-buildpackage directly for PPA source build (v1.0.21)

### DIFF
--- a/.github/workflows/ppa-upload.yaml
+++ b/.github/workflows/ppa-upload.yaml
@@ -51,12 +51,13 @@ jobs:
 
       - name: Build source package
         run: |
-          # --no-pre-clean prevents dpkg-buildpackage from running
-          # debian/rules clean before packaging the source — without it,
-          # debian/wheels/ is deleted before the .debian.tar.xz is created,
-          # so Launchpad receives a source package with no wheels and cannot
-          # download them (sandboxed build environment, no internet).
-          debuild -S -sa -d -k"$GPG_KEY_ID" -- --no-pre-clean
+          # Use dpkg-buildpackage directly instead of debuild:
+          # debuild injects --rules-target before extra args, turning
+          # "-- --no-pre-clean" into "--rules-target --no-pre-clean" which
+          # calls debian/rules with --no-pre-clean as a make target (fails).
+          # dpkg-buildpackage -S --no-pre-clean skips debian/rules clean so
+          # debian/wheels/ is still present when the source is packaged.
+          dpkg-buildpackage -S -sa -d --no-pre-clean -k"$GPG_KEY_ID"
 
       - name: Upload to PPA
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.21] - 9 April 2026
+
+### Fixed
+
+- **PPA source build**: replaced `debuild -- --no-pre-clean` with `dpkg-buildpackage -S --no-pre-clean` — `debuild` was injecting `--rules-target` before the extra argument, calling `debian/rules --no-pre-clean` as a make target (exit 2). `dpkg-buildpackage` accepts `--no-pre-clean` directly and skips the clean step so `debian/wheels/` survives into the source package.
+
 ## [1.0.20] - 9 April 2026
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arctis-sound-manager"
-version = "1.0.20"
+version = "1.0.21"
 description = "A replacement for SteelSeries GG software, to manage your Arctis device on Linux!"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
`debuild -- --no-pre-clean` → debuild injecte `--rules-target` avant les extra args → appel de `debian/rules --no-pre-clean` comme target make → exit 2.

`dpkg-buildpackage -S -sa -d --no-pre-clean` fonctionne directement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)