### PR TITLE
feat(nix): add NixOS packaging — flake, classic shim, and NixOS module

### DIFF
--- a/nix/README.md
+++ b/nix/README.md
@@ -1,0 +1,185 @@
+# Arctis Sound Manager on NixOS
+
+Native Nix packaging for [Arctis Sound Manager](https://github.com/loteran/Arctis-Sound-Manager)
+— no distrobox, no `unset QT_PLUGIN_PATH …` dance, and the audio survives reboots
+and service restarts.
+
+It builds the **unmodified upstream source** and wraps it so it runs natively:
+
+- **Qt env bleed fixed.** The wrappers bake in the correct nixpkgs `QT_PLUGIN_PATH`
+  / `QML2_IMPORT_PATH` (qtbase Wayland+xcb platforms, qtwayland integration,
+  qtsvg). A bad inherited `QT_PLUGIN_PATH` from the host can no longer crash
+  PySide6 — that's what broke the Arch-in-distrobox setup.
+- **libusb / libudev** are on `LD_LIBRARY_PATH` for the pyusb / pyudev backends.
+- **pw-\* / wpctl / pgrep / systemctl / curl** are on `PATH` so the runtime EQ
+  config generator and the "restart filter-chain" path work.
+- The NixOS module installs the **udev rules** (every Arctis PID incl. Nova Pro
+  Wireless `0x12e0`/`0x12e5`), the **daemon / media-router / filter-chain**
+  systemd user services, and the **LADSPA plugins** the Sonar EQ needs
+  (`swh-plugins` → SC4 compressor, plate reverb, gate; `rnnoise-plugin`).
+
+Everything is pinned to nixpkgs **25.11** (`nix/sources.nix` + `flake.lock`), so
+it builds reproducibly whether or not your system has flakes enabled.
+
+---
+
+## Quick start (classic — flakes disabled)
+
+This is the path for a system **without** `nix-command`/`flakes`.
+
+1. Clone the repo somewhere persistent (e.g. inside your nixos config tree):
+
+   ```bash
+   git clone https://github.com/loteran/Arctis-Sound-Manager.git /etc/nixos/Arctis-Sound-Manager
+   ```
+
+2. In `/etc/nixos/configuration.nix`:
+
+   ```nix
+   {
+     imports = [ /etc/nixos/Arctis-Sound-Manager/nix/module.nix ];
+
+     # PipeWire is required (it's the audio backend ASM drives).
+     services.pipewire = {
+       enable = true;
+       alsa.enable = true;
+       pulse.enable = true;
+     };
+
+     services.arctis-sound-manager.enable = true;
+   }
+   ```
+
+3. Rebuild and replug the headset once (so udev applies the new rules):
+
+   ```bash
+   sudo nixos-rebuild switch
+   ```
+
+The tray GUI starts on next login (`services.arctis-sound-manager.autostartTray`,
+on by default). The daemon creates the `Arctis_Game` / `Arctis_Chat` /
+`Arctis_Media` virtual sinks when the headset connects; assign apps to them from
+KDE's audio applet or ASM's mixer. Per-channel Sonar EQ and HeSuVi 7.1 spatial
+work out of the box.
+
+> **Spatial audio (HeSuVi) first run:** pick an HRIR profile in
+> **Settings → Spatial Audio** — that copies one of the 58 bundled profiles to
+> `~/.local/share/pipewire/hrir_hesuvi/hrir.wav` (offline, no download needed).
+>
+> **Do not run `asm-setup` on NixOS.** It's for traditional distros: it copies
+> read-only files out of the Nix store into `~/.config` (which fails on re-run
+> and can leave configs the daemon can't rewrite). This module + the
+> `arctis-manager` daemon already handle udev, services, and every PipeWire
+> config, so it isn't needed.
+
+### Just the package, no module
+
+```bash
+nix-build /etc/nixos/Arctis-Sound-Manager/nix     # → ./result/bin/asm-gui …
+nix-shell /etc/nixos/Arctis-Sound-Manager/nix     # drops the asm-* tools on PATH
+```
+
+---
+
+## Flake-based NixOS config (pure eval)
+
+If your system config is itself a flake (e.g. `nixosConfigurations.<host>`), do
+**not** `imports = [ /abs/path/nix/module.nix ]` — pure flake evaluation forbids
+importing arbitrary absolute paths (`access to absolute path … is forbidden in
+pure evaluation mode`). Add this flake as an **input** instead:
+
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+
+    arctis-sound-manager = {
+      # Local checkout. Or: "github:loteran/Arctis-Sound-Manager?dir=nix"
+      url = "git+file:///opt/projects/Arctis-Sound-Manager?dir=nix";
+      inputs.nixpkgs.follows = "nixpkgs";   # share one nixpkgs
+    };
+  };
+
+  outputs = { self, nixpkgs, arctis-sound-manager, ... }: {
+    nixosConfigurations.senate = nixpkgs.lib.nixosSystem {
+      system = "x86_64-linux";
+      modules = [
+        arctis-sound-manager.nixosModules.default
+        {
+          services.pipewire.enable = true;
+          services.arctis-sound-manager.enable = true;
+        }
+        # … your other modules …
+      ];
+    };
+  };
+}
+```
+
+`nixosModules.default` defaults the package to the flake's pinned build.
+
+> **Lockability:** a local `git+file://…` input only locks cleanly when `nix/`
+> is committed (an uncommitted/dirty tree works but logs "not writing lock
+> file … unlocked input" and re-copies each build). Commit `nix/`, or push and
+> use the `github:…?dir=nix` URL, to pin it in your `flake.lock`.
+
+Ad-hoc builds:
+
+```bash
+nix build "git+file:///opt/projects/Arctis-Sound-Manager?dir=nix#default"
+```
+
+---
+
+## Module options
+
+| Option | Default | Notes |
+|---|---|---|
+| `services.arctis-sound-manager.enable` | `false` | Master switch. Asserts `services.pipewire.enable`. |
+| `…​.package` | built from `nix/sources.nix` pin | Override to use your own build. |
+| `…​.ladspaPlugins` | `[ pkgs.ladspaPlugins pkgs.rnnoise-plugin ]` | On the filter-chain's `LADSPA_PATH`. |
+| `…​.autostartTray` | `true` | Launch `asm-gui --systray` on login. |
+
+What the module configures:
+
+- `environment.systemPackages` → `asm-gui`, `asm-daemon`, `asm-cli`, `asm-router`, `asm-setup`.
+- `services.udev.packages` → `91-steelseries-arctis.rules`.
+- `systemd.user.services.{arctis-manager,arctis-video-router,filter-chain,arctis-gui}`.
+- `systemd.tmpfiles` symlink `/usr/lib/ladspa` → the Sonar LADSPA plugins
+  (so ASM's FHS-only dependency checker finds plate_1423 / rnnoise).
+
+The per-user PipeWire configs in `~/.config/pipewire/…` are generated by the
+daemon at runtime when the headset connects (and self-healed on startup), so
+nothing user-specific is managed declaratively here.
+
+---
+
+## Troubleshooting
+
+```bash
+systemctl --user status arctis-manager arctis-video-router filter-chain
+journalctl --user -u arctis-manager -f
+ARCTIS_LOG_LEVEL=debug systemctl --user restart arctis-manager
+asm-daemon --verify-setup          # preflight: device YAMLs, deps, udev, pipewire
+```
+
+- **Headset not detected:** confirm the udev rule applied — replug, or
+  `udevadm info -a /dev/bus/usb/... | grep uaccess`. The rules need a reboot or
+  replug after the first `nixos-rebuild switch`.
+- **No virtual sinks:** check `pactl list sinks short | grep -i arctis`; the
+  daemon only creates them while the headset is powered on and connected.
+- **Sonar EQ silent / no compressor:** verify `filter-chain.service` is running
+  and `LADSPA_PATH` resolves — `systemctl --user show filter-chain -p Environment`.
+
+---
+
+## Updating the pin
+
+Bump the revision in **both** `nix/sources.nix` (rev + sha256) and
+`nix/flake.nix` (input url), then for flake users `nix flake lock --update-input nixpkgs ./nix`.
+Get the classic sha256 with:
+
+```bash
+nix-prefetch-url --unpack \
+  "https://github.com/NixOS/nixpkgs/archive/<rev>.tar.gz" --name source
+```

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,9 @@
+# Classic (non-flakes) entry point: `nix-build nix` builds the package against
+# the pinned nixpkgs in sources.nix.
+#
+#   nix-build nix                       # build with the pinned nixpkgs
+#   nix-build nix --arg pkgs 'import <nixpkgs> {}'   # or against your channel
+{
+  pkgs ? import (import ./sources.nix).nixpkgs { },
+}:
+pkgs.callPackage ./package.nix { }

--- a/nix/flake.lock
+++ b/nix/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1778003029,
+        "narHash": "sha256-q/nkKLDtHIyLjZpKhWk3cSK5IYsFqtMd6UtXF3ddjgA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -1,0 +1,52 @@
+{
+  description = "Arctis Sound Manager — Nix package + NixOS module (SteelSeries headset control over PipeWire)";
+
+  # Pinned to the same nixpkgs revision as nix/sources.nix (the classic path).
+  # Keep flake.lock in sync when bumping.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+      ];
+      forAllSystems = nixpkgs.lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          arctis-sound-manager = (pkgsFor system).callPackage ./package.nix { };
+        in
+        {
+          inherit arctis-sound-manager;
+          default = arctis-sound-manager;
+        }
+      );
+
+      devShells = forAllSystems (system: {
+        default = import ./shell.nix { pkgs = pkgsFor system; };
+      });
+
+      overlays.default = final: _prev: {
+        arctis-sound-manager = final.callPackage ./package.nix { };
+      };
+
+      # Flake users get the flake's pinned package by default; classic importers
+      # of ./module.nix get nix/default.nix (same pin).
+      nixosModules.default =
+        { pkgs, lib, ... }:
+        {
+          imports = [ ./module.nix ];
+          services.arctis-sound-manager.package =
+            lib.mkDefault
+              self.packages.${pkgs.stdenv.hostPlatform.system}.default;
+        };
+      nixosModules.arctis-sound-manager = self.nixosModules.default;
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt-rfc-style);
+    };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,177 @@
+# NixOS module for Arctis Sound Manager.
+#
+# Reproduces, declaratively, what the upstream `asm-setup` does on a regular
+# distro — udev rules, the daemon / media-router services, and the LADSPA
+# plugins the Sonar EQ needs — so the headset works after every reboot without a
+# container and without scrubbing the Qt environment by hand.
+#
+# It does NOT define its own filter-chain service: PipeWire already ships
+# `filter-chain.service` (runs `pipewire -c filter-chain.conf`, which loads
+# `~/.config/pipewire/filter-chain.conf.d/` — exactly where the ASM daemon writes
+# the Sonar EQ + HeSuVi surround configs). We just add the Sonar LADSPA plugins
+# to it and make sure it's started.
+#
+# Usage — in your flake's nixosSystem modules (or imports for a non-flake config):
+#
+#   services.pipewire.enable = true;            # + alsa/pulse as you like
+#   services.arctis-sound-manager.enable = true;
+#
+# then rebuild. The system tray launches on login; replug the headset once after
+# the first switch so udev applies the new rules.
+{
+  config,
+  lib,
+  pkgs,
+  options,
+  ...
+}:
+
+let
+  cfg = config.services.arctis-sound-manager;
+
+  userService =
+    extra:
+    lib.recursiveUpdate {
+      wantedBy = [ "graphical-session.target" ];
+      partOf = [ "graphical-session.target" ];
+      serviceConfig = {
+        Restart = "on-failure";
+        RestartSec = 5;
+      };
+    } extra;
+
+  # The Sonar EQ / surround filter-chain loads these LADSPA plugins by name:
+  #   sc4m_1916 (Smart Volume + mic compressor), plate_1423 (Distance reverb),
+  #   gate_1410 (mic noise gate)  → swh-plugins (pkgs.ladspaPlugins)
+  #   librnnoise_ladspa (mic noise cancellation) → pkgs.rnnoise-plugin
+  #
+  # Newer nixpkgs expose `services.pipewire.extraLadspaPackages`, which feeds the
+  # filter-chain service's LADSPA_PATH directly. Older releases lack it (their
+  # filter-chain service only sets LV2_PATH); there we set LADSPA_PATH on the
+  # service ourselves — no conflict, since those versions don't define it.
+  pipewireHasLadspaOption = options.services.pipewire ? extraLadspaPackages;
+
+  # One directory holding all configured LADSPA plugins, symlinked to
+  # /usr/lib/ladspa below. ASM's GUI dependency checker scans only the FHS dirs
+  # (/usr/lib/ladspa, /usr/lib64/ladspa, …) and ignores $LADSPA_PATH, so on NixOS
+  # it falsely reports plate_1423 / rnnoise "missing" even though they're on the
+  # filter-chain's path. This makes the checker pass; it's also a default LADSPA
+  # search dir, so the filter-chain finds them regardless.
+  ladspaEnv = pkgs.buildEnv {
+    name = "asm-ladspa-plugins";
+    paths = cfg.ladspaPlugins;
+    pathsToLink = [ "/lib/ladspa" ];
+  };
+in
+{
+  options.services.arctis-sound-manager = {
+    enable = lib.mkEnableOption "Arctis Sound Manager (SteelSeries headset control over PipeWire)";
+
+    package = lib.mkOption {
+      type = lib.types.package;
+      default = import ./default.nix { };
+      defaultText = lib.literalExpression "import ./default.nix { } (built from the pinned nixpkgs in nix/sources.nix)";
+      description = "The arctis-sound-manager package to use.";
+    };
+
+    ladspaPlugins = lib.mkOption {
+      type = lib.types.listOf lib.types.package;
+      default = [
+        pkgs.ladspaPlugins
+        pkgs.rnnoise-plugin
+      ];
+      defaultText = lib.literalExpression "[ pkgs.ladspaPlugins pkgs.rnnoise-plugin ]";
+      description = ''
+        LADSPA plugin packages added to the PipeWire filter-chain's LADSPA_PATH.
+        The Sonar EQ uses sc4m_1916 / plate_1423 / gate_1410 (swh-plugins) and
+        librnnoise_ladspa (rnnoise). Override only if you ship them elsewhere.
+      '';
+    };
+
+    autostartTray = lib.mkOption {
+      type = lib.types.bool;
+      default = true;
+      description = "Launch the system-tray GUI (`asm-gui --systray`) on login.";
+    };
+  };
+
+  config = lib.mkIf cfg.enable (
+    lib.mkMerge [
+      {
+        assertions = [
+          {
+            assertion = config.services.pipewire.enable;
+            message = ''
+              services.arctis-sound-manager requires PipeWire.
+              Set services.pipewire.enable = true; (with pulse/alsa support as desired).
+            '';
+          }
+        ];
+
+        environment.systemPackages = [ cfg.package ];
+
+        # USB HID access for every Arctis PID (no manual /etc/udev write needed).
+        services.udev.packages = [ cfg.package ];
+
+        # ASM's GUI dependency checker scans FHS LADSPA dirs and ignores
+        # $LADSPA_PATH, so expose the Sonar plugins at /usr/lib/ladspa
+        # (plate_1423 / rnnoise). It's also a default LADSPA search dir.
+        #
+        # We deliberately do NOT symlink /usr/share/arctis-sound-manager: that
+        # would let `asm-setup` copy read-only store files into ~/.config, which
+        # the daemon then cannot rewrite (issue #23 territory). The daemon
+        # generates every PipeWire config itself, so asm-setup isn't needed here.
+        systemd.tmpfiles.rules = [
+          "L+ /usr/lib/ladspa - - - - ${ladspaEnv}/lib/ladspa"
+        ];
+
+        systemd.user.services = {
+          # Start PipeWire's own filter-chain service so the Sonar EQ + HeSuVi
+          # configs in ~/.config/pipewire/filter-chain.conf.d/ load at login (the
+          # ASM daemon restarts it by this exact name when applying EQ changes).
+          filter-chain.wantedBy = [ "default.target" ];
+
+          arctis-manager = userService {
+            description = "Arctis Sound Manager device daemon";
+            after = [
+              "pipewire.service"
+              "pipewire-pulse.service"
+            ];
+            wants = [ "pipewire.service" ];
+            serviceConfig.ExecStart = "${cfg.package}/bin/asm-daemon";
+          };
+
+          arctis-video-router = userService {
+            description = "Arctis Sound Manager media auto-router";
+            after = [
+              "pipewire.service"
+              "arctis-manager.service"
+            ];
+            serviceConfig.ExecStart = "${cfg.package}/bin/asm-router";
+          };
+        }
+        // lib.optionalAttrs cfg.autostartTray {
+          arctis-gui = userService {
+            description = "Arctis Sound Manager tray GUI";
+            after = [
+              "graphical-session.target"
+              "arctis-manager.service"
+            ];
+            serviceConfig.ExecStart = "${cfg.package}/bin/asm-gui --systray --no-enforce-systemd";
+          };
+        };
+      }
+
+      # Feed the Sonar LADSPA plugins into PipeWire's filter-chain service.
+      (
+        if pipewireHasLadspaOption then
+          { services.pipewire.extraLadspaPackages = cfg.ladspaPlugins; }
+        else
+          {
+            systemd.user.services.filter-chain.environment.LADSPA_PATH =
+              lib.makeSearchPath "lib/ladspa" cfg.ladspaPlugins;
+          }
+      )
+    ]
+  );
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,172 @@
+# Arctis Sound Manager packaged for Nix.
+#
+# Builds the *unmodified* upstream source (src/ layout, uv_build backend) and
+# wraps every entry point so it runs natively on NixOS:
+#   - Qt plugin paths are baked into the wrappers → no more `unset QT_PLUGIN_PATH …`.
+#   - libusb / libudev are on LD_LIBRARY_PATH for the pyusb / pyudev ctypes backends.
+#   - pactl, pw-*, wpctl, pgrep, systemctl, curl are on PATH so the runtime
+#     config generator and "restart filter-chain" actions work.
+#
+# callPackage-style: usable from both the flake and the classic default.nix.
+{
+  lib,
+  python3Packages,
+  qt6,
+  libusb1,
+  systemd, # libudev (pyudev) + systemctl/udevadm
+  pipewire, # pw-metadata / pw-dump / pw-cli
+  wireplumber, # wpctl
+  pulseaudio, # pactl (client tool; not shipped by pipewire on NixOS)
+  procps, # pgrep (asm-router singleton guard)
+  coreutils,
+  curl, # HRIR download in asm-setup
+}:
+
+let
+  # Only the files the wheel + packaging steps need. Keeps the build input small
+  # and avoids rebuilds when unrelated repo files (docs, top-level hrir/, aur/…)
+  # change. The 58 selectable HRIR profiles live under src/.../hrir_assets and
+  # are included via ../src.
+  src = lib.fileset.toSource {
+    root = ../.;
+    fileset = lib.fileset.unions [
+      ../pyproject.toml
+      ../README.md
+      ../LICENSE
+      ../src
+      ../scripts/generate_udev_rules.py
+    ];
+  };
+
+  # A tiny python that can run the udev-rule generator at build time (it needs
+  # ruamel.yaml to parse the device YAMLs). Single source of truth: identical
+  # output to `asm-cli udev dump-rules`.
+  udevGenPython = python3Packages.python.withPackages (ps: [ ps.ruamel-yaml ]);
+in
+python3Packages.buildPythonApplication {
+  pname = "arctis-sound-manager";
+  version = "1.1.36";
+  pyproject = true;
+  inherit src;
+
+  build-system = [ python3Packages.uv-build ];
+
+  # nixpkgs 25.11 ships these a hair below the pyproject floor (pyside6 6.10.0
+  # vs .1, pyudev 0.24.3 vs .4, ruamel 0.18.14 vs 0.19.1). The differences are
+  # functionally irrelevant for ASM's usage; relax the bounds rather than
+  # patching upstream.
+  pythonRelaxDeps = [
+    "pyside6"
+    "pyudev"
+    "ruamel-yaml"
+  ];
+
+  dependencies = with python3Packages; [
+    babel
+    dbus-next
+    pillow
+    pulsectl
+    pyside6
+    pyudev
+    pyusb
+    ruamel-yaml
+  ];
+
+  # nixpkgs 25.11 ships uv-build 0.9.7; pyproject pins the backend to
+  # >=0.9.17. Lower the floor on the sandbox copy only — the repo's
+  # pyproject.toml is untouched. (Build-system requires are verified by
+  # `python -m build`, so pythonRelaxDeps can't cover this one.)
+  postPatch = ''
+    substituteInPlace pyproject.toml \
+      --replace-fail 'uv_build>=0.9.17,<0.12' 'uv_build>=0.9.7'
+  '';
+
+  # We wrap the Python entry points ourselves (makeWrapperArgs below), so tell
+  # the qt6 stdenv guard not to expect wrapQtAppsHook. Without this, depending
+  # on qtbase fails with "no wrapping behavior was specified".
+  dontWrapQtApps = true;
+
+  # Qt plugin dirs are wired in explicitly via makeWrapperArgs below, so the
+  # buildInputs here exist mainly to pull qtbase/qtwayland/qtsvg into the
+  # runtime closure (referenced by those wrapper paths).
+  buildInputs = [
+    libusb1
+    qt6.qtbase # platform (xcb) + base plugins
+    qt6.qtwayland # Wayland QPA platform plugin (user is on KDE Wayland)
+    qt6.qtsvg # imageformat plugin — ASM's UI icons are SVG
+  ];
+
+  # Bake everything the Python entry points need straight into their wrappers:
+  #   - QT_PLUGIN_PATH / QML2_IMPORT_PATH → the nixpkgs qt6 plugin dirs. This is
+  #     the fix for the host Qt env bleed (a wrong inherited QT_PLUGIN_PATH is
+  #     what crashes the distrobox PySide6); --prefix puts the correct dirs
+  #     first no matter what the session exports.
+  #   - LD_LIBRARY_PATH → libusb (pyusb) + libudev (pyudev) ctypes backends.
+  #   - PATH → pw-* / wpctl / pgrep / systemctl / curl used at runtime.
+  #
+  # Set as Nix-level strings rather than via wrapQtAppsHook's qtWrapperArgs: the
+  # hook only wraps ELF binaries (it skips the Python entry points), and the
+  # usual `makeWrapperArgs+=("''${qtWrapperArgs[@]}")` merge silently drops the
+  # Qt entries here because, without structuredAttrs, makeWrapperArgs is a
+  # scalar string and the array append mangles it.
+  makeWrapperArgs = [
+    "--prefix QT_PLUGIN_PATH : ${
+      lib.makeSearchPath qt6.qtbase.qtPluginPrefix [
+        qt6.qtbase
+        qt6.qtwayland
+        qt6.qtsvg
+      ]
+    }"
+    "--prefix QML2_IMPORT_PATH : ${lib.makeSearchPath qt6.qtbase.qtQmlPrefix [ qt6.qtwayland ]}"
+    "--prefix LD_LIBRARY_PATH : ${
+      lib.makeLibraryPath [
+        libusb1
+        systemd
+      ]
+    }"
+    "--prefix PATH : ${
+      lib.makeBinPath [
+        pipewire
+        wireplumber
+        pulseaudio
+        procps
+        coreutils
+        curl
+        systemd
+      ]
+    }"
+  ];
+
+  # Don't run the test suite here: tests import pulsectl/PySide6 against a live
+  # PipeWire + display that the sandbox doesn't have.
+  doCheck = false;
+  pythonImportsCheck = [ "arctis_sound_manager" ];
+
+  postInstall = ''
+    # udev rules generated from the device YAMLs (covers every Arctis PID,
+    # including Nova Pro Wireless 0x12e0 / 0x12e5). services.udev.packages in
+    # the NixOS module picks these up from $out/lib/udev/rules.d.
+    install -d "$out/lib/udev/rules.d"
+    ${udevGenPython}/bin/python scripts/generate_udev_rules.py \
+      src/arctis_sound_manager/devices \
+      > "$out/lib/udev/rules.d/91-steelseries-arctis.rules"
+
+    # Desktop entry + icon
+    install -Dm644 src/arctis_sound_manager/desktop/ArctisManager.desktop \
+      "$out/share/applications/ArctisManager.desktop"
+    substituteInPlace "$out/share/applications/ArctisManager.desktop" \
+      --replace-fail "Exec=asm-gui" "Exec=$out/bin/asm-gui"
+    install -Dm644 src/arctis_sound_manager/gui/images/steelseries_logo.svg \
+      "$out/share/icons/hicolor/scalable/apps/arctis-manager.svg"
+  '';
+
+  passthru.updateScript = null;
+
+  meta = {
+    description = "Linux GUI for SteelSeries Arctis headsets — mixer, per-channel Sonar EQ and HeSuVi 7.1 surround over PipeWire";
+    homepage = "https://github.com/loteran/Arctis-Sound-Manager";
+    license = lib.licenses.gpl3Only;
+    mainProgram = "asm-gui";
+    platforms = lib.platforms.linux;
+  };
+}

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -1,0 +1,24 @@
+# Classic dev shell: `nix-shell nix` drops you into an environment where the
+# wrapped asm-* tools are on PATH (Qt env correct, libusb/libudev present), plus
+# uv for working on the upstream source.
+#
+#   nix-shell nix
+#   asm-gui            # runs the built GUI, no `unset QT_PLUGIN_PATH …` needed
+{
+  pkgs ? import (import ./sources.nix).nixpkgs { },
+}:
+let
+  asm = pkgs.callPackage ./package.nix { };
+in
+pkgs.mkShell {
+  packages = [
+    asm
+    pkgs.uv
+    pkgs.python3
+  ];
+
+  shellHook = ''
+    echo "Arctis Sound Manager dev shell (${asm.version})"
+    echo "  asm-gui / asm-daemon / asm-cli / asm-router / asm-setup are on PATH."
+  '';
+}

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -1,0 +1,18 @@
+# Pinned dependencies for the classic (non-flakes) entry points.
+#
+# This is the single source of truth for `default.nix`, `shell.nix` and the
+# NixOS module's default package, so a system with flakes *disabled* still gets
+# a fully reproducible build. The flake (`flake.nix`) pins the same revision via
+# its own input, kept in sync by `flake.lock`.
+#
+# Revision: nixos-25.11 channel (0c88e1f2bdb9), the version this was developed
+# and test-built against. Bump `rev` + `sha256` together; get the new hash with:
+#   nix-prefetch-url --unpack \
+#     "https://github.com/NixOS/nixpkgs/archive/<rev>.tar.gz" --name source
+{
+  nixpkgs = fetchTarball {
+    name = "nixpkgs-25.11-arctis";
+    url = "https://github.com/NixOS/nixpkgs/archive/0c88e1f2bdb93d5999019e99cb0e61e1fe2af4c5.tar.gz";
+    sha256 = "004fbmvifmsbx4fx7ah5ichvj8ki6xlqajlsin5qq77dn0lf9ydb";
+  };
+}


### PR DESCRIPTION
**DISCLAIMER: THIS IS 100% Vibecoded!**

Self-contained nix/ subfolder to run Arctis Sound Manager natively on NixOS without distrobox. Upstream Python is unmodified.

- package.nix: buildPythonApplication wrapping the upstream source. Bakes the qt6 plugin paths (Wayland/xcb/SVG) + libusb/libudev + pactl/pw-*/wpctl into the entry-point wrappers, which fixes the host Qt env bleed (no more `unset QT_PLUGIN_PATH`). Generates udev rules from the device YAMLs and installs the desktop entry + icon.
- module.nix: NixOS module — udev rules, daemon/media-router/tray systemd user services, and the Sonar LADSPA plugins (swh-plugins + rnnoise) fed into PipeWire's own filter-chain service. Symlinks /usr/lib/ladspa so ASM's FHS-only dependency checker finds plate_1423 / rnnoise.
- flake.nix + flake.lock plus a classic default.nix / shell.nix shim, pinned to nixpkgs 25.11 (nix/sources.nix), so it builds whether or not flakes are on.
- README.md: setup, flake-input usage under pure eval, and troubleshooting.

Built and validated against nixpkgs 25.11 and nixos-unstable.

This NixOS packaging was developed with Claude Code (Claude Opus 4.7).