### PR TITLE
fix(nix): add bash, dbus-send & pkexec to the wrapper PATH

### DIFF
--- a/nix/package.nix
+++ b/nix/package.nix
@@ -19,6 +19,7 @@
   pulseaudio, # pactl (client tool; not shipped by pipewire on NixOS)
   procps, # pgrep (asm-router singleton guard)
   coreutils,
+  bash, # sig_stop runs `bash -c "… systemctl --user restart pipewire …"` on GUI quit
   curl, # HRIR download in asm-setup
   dbus, # dbus-send (bug-report D-Bus diagnostic dump)
 }:
@@ -103,9 +104,10 @@ python3Packages.buildPythonApplication {
   #     what crashes the distrobox PySide6); --prefix puts the correct dirs
   #     first no matter what the session exports.
   #   - LD_LIBRARY_PATH → libusb (pyusb) + libudev (pyudev) ctypes backends.
-  #   - PATH → pactl / pw-* / wpctl / pgrep / systemctl / curl / dbus-send used
-  #     at runtime, plus /run/wrappers/bin for the setuid pkexec (a BLOCKING
-  #     dep check) that systemd user services don't otherwise inherit.
+  #   - PATH → pactl / pw-* / wpctl / pgrep / systemctl / curl / dbus-send /
+  #     bash used at runtime (bash: sig_stop restarts pipewire via `bash -c` on
+  #     GUI quit), plus /run/wrappers/bin for the setuid pkexec (a BLOCKING dep
+  #     check) that systemd user services don't otherwise inherit.
   #
   # Set as Nix-level strings rather than via wrapQtAppsHook's qtWrapperArgs: the
   # hook only wraps ELF binaries (it skips the Python entry points), and the
@@ -134,6 +136,7 @@ python3Packages.buildPythonApplication {
         pulseaudio
         procps
         coreutils
+        bash
         curl
         systemd
         dbus

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -20,6 +20,7 @@
   procps, # pgrep (asm-router singleton guard)
   coreutils,
   curl, # HRIR download in asm-setup
+  dbus, # dbus-send (bug-report D-Bus diagnostic dump)
 }:
 
 let
@@ -102,7 +103,9 @@ python3Packages.buildPythonApplication {
   #     what crashes the distrobox PySide6); --prefix puts the correct dirs
   #     first no matter what the session exports.
   #   - LD_LIBRARY_PATH → libusb (pyusb) + libudev (pyudev) ctypes backends.
-  #   - PATH → pw-* / wpctl / pgrep / systemctl / curl used at runtime.
+  #   - PATH → pactl / pw-* / wpctl / pgrep / systemctl / curl / dbus-send used
+  #     at runtime, plus /run/wrappers/bin for the setuid pkexec (a BLOCKING
+  #     dep check) that systemd user services don't otherwise inherit.
   #
   # Set as Nix-level strings rather than via wrapQtAppsHook's qtWrapperArgs: the
   # hook only wraps ELF binaries (it skips the Python entry points), and the
@@ -133,8 +136,13 @@ python3Packages.buildPythonApplication {
         coreutils
         curl
         systemd
+        dbus
       ]
     }"
+    # pkexec is a setuid wrapper at /run/wrappers/bin on NixOS (never a store
+    # path); systemd user services don't inherit it. Suffix so it's found
+    # without shadowing anything.
+    "--suffix PATH : /run/wrappers/bin"
   ];
 
   # Don't run the test suite here: tests import pulsectl/PySide6 against a live


### PR DESCRIPTION
Two follow-up fixes to the NixOS packaging, found running it daily on NixOS:

- dbus-send + pkexec — ASM's startup dependency checker scans PATH for pkexec (BLOCKING) and dbus-send (DEGRADED); on NixOS neither is on 
the wrapped process's PATH, so the GUI reports "components missing" on every launch. Adds dbus (dbus-send) and /run/wrappers/bin via 
--suffix (NixOS's setuid pkexec lives there, never in a store path).
- bash — systray_app.sig_stop() runs bash -c "… systemctl --user restart pipewire …" on GUI quit; with no bash on the wrapped PATH this 
raises FileNotFoundError, writes a crash_report.json, and pops the bug-report dialog on next login. Adds bash.

Both touch only nix/package.nix (wrapper PATH). Verified: nix build produces arctis-sound-manager-1.1.40 and the GUI launches clean.