### PR TITLE
diag: collect PipeWire runtime / container diagnostics (issue #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,17 @@ A Linux GUI for SteelSeries Arctis headsets — device settings, 4-channel audio
 | Arctis 7+ / PS5 / Xbox / Destiny | ✅ | 4 | $\color{royalblue}{\textbf{220e}}$, 2212, 2216, 2236 |
 | Arctis 9 Wireless | ✅ | 3 | $\color{royalblue}{\textbf{12c2}}$ |
 | Arctis Pro Wireless | ✅ | 7 | $\color{royalblue}{\textbf{1290}}$, $\color{royalblue}{\textbf{1294}}$ |
-| Arctis Nova Pro Wireless / X | ✅ | 37 | $\color{royalblue}{\textbf{12e0}}$, $\color{royalblue}{\textbf{12e5}}$ |
+| Arctis Nova Pro Wireless / X | ✅ | 44 | $\color{royalblue}{\textbf{12e0}}$, $\color{royalblue}{\textbf{12e5}}$ |
 | Arctis Nova Pro Wired / Xbox Wired | ✅ | 5 | $\color{royalblue}{\textbf{12cb}}$, 12cd |
 | Arctis Nova Pro Omni | ✅ | 1 | $\color{royalblue}{\textbf{2290}}$ |
-| Arctis Nova 3 | ✅ | 6 | $\color{royalblue}{\textbf{12ec}}$ |
-| Arctis Nova 3P / 3X Wireless | ✅ | 6 | $\color{royalblue}{\textbf{2269}}$, 226d |
+| Arctis Nova 3 | ✅ | 5 | $\color{royalblue}{\textbf{12ec}}$ |
+| Arctis Nova 3P / 3X Wireless | ✅ | 5 | $\color{royalblue}{\textbf{2269}}$, 226d |
 | Arctis Nova 5 / 5X | ✅ | 6 | $\color{royalblue}{\textbf{2232}}$, 2253, $\color{royalblue}{\textbf{2255}}$ |
 | Arctis Nova 7 Gen 1 | ✅ | 5 | $\color{royalblue}{\textbf{2202}}$, $\color{royalblue}{\textbf{2206}}$, 223a, 227a, 22ab, 22a4 |
 | Arctis Nova 7 Gen 2 | ✅ | 23 | $\color{royalblue}{\textbf{22a1}}$, $\color{royalblue}{\textbf{227e}}$, 2258, $\color{royalblue}{\textbf{229e}}$, 22a9, $\color{royalblue}{\textbf{22a5}}$ |
 | Arctis Nova 7P | ✅ | 6 | 220a, $\color{royalblue}{\textbf{22a7}}$ |
 | Arctis Nova Elite | ✅ | 2 | $\color{royalblue}{\textbf{2244}}$, 2249 |
-| Arctis GameBuds / GameBuds X | ✅ | 2 | $\color{royalblue}{\textbf{230a}}$, $\color{royalblue}{\textbf{2317}}$ |
+| Arctis GameBuds / GameBuds X | ✅ | 3 | $\color{royalblue}{\textbf{230a}}$, $\color{royalblue}{\textbf{2317}}$ |
 <!-- STATS:DEVICES:END -->
 
 > ✅ Confirmed by at least one opted-in user
@@ -478,7 +478,7 @@ To request a new language, open a [GitHub issue](https://github.com/loteran/Arct
 ## Community stats
 
 <!-- STATS:META:START -->
-_Based on **113** unique users (**649** anonymous data points) — last updated 2026-06-09_
+_Based on **120** unique users (**679** anonymous data points) — last updated 2026-06-10_
 <!-- STATS:META:END -->
 
 > Anonymous usage data shared voluntarily by opted-in users.
@@ -490,8 +490,8 @@ _Based on **113** unique users (**649** anonymous data points) — last updated 
 <!-- STATS:TESTED_DISTROS:START -->
 | Distribution | Install method | Users |
 |---|---|---|
-| CachyOS | 🎯 AUR | 👥 56 |
-| Arch Linux | 🎯 AUR | 👥 14 |
+| CachyOS | 🎯 AUR | 👥 57 |
+| Arch Linux | 🎯 AUR | 👥 15 |
 | Nobara Linux 43 (KDE Plasma Desktop Edition) | 🎯 COPR | 👥 8 |
 | Ubuntu 26.04 LTS | 🎯 PPA | 👥 7 |
 | Garuda Linux | 🎯 AUR | 👥 5 |
@@ -499,11 +499,14 @@ _Based on **113** unique users (**649** anonymous data points) — last updated 
 | Ubuntu 24.04.4 LTS | 🎯 PPA | 👥 3 |
 | Linux Mint 22.3 | 🎯 PPA | 👥 3 |
 | Artix Linux | 🎯 AUR | 👥 3 |
+| SteamOS | 📦 Source | 👥 2 |
+| Pop!_OS 24.04 LTS | 🎯 PPA | 👥 2 |
 | Manjaro Linux | 🎯 AUR | 👥 2 |
 | EndeavourOS | 🎯 AUR | 👥 2 |
+| SUSE Linux Enterprise Server for SAP Applications 12 SP2 | 📦 Source | 👥 1 |
+| Russian Nuclear Submarine Ballast Management Controller BMC (OpenBMC Project Reference Distro) 2.8.2-34 | 📦 Source | 👥 1 |
 | PikaOS 4 | 📦 Source | 👥 1 |
 | NixOS 26.05 (Yarara) | 📦 Source | 👥 1 |
-| Fedora Linux 44 (Workstation Edition) | 🎯 COPR | 👥 1 |
 | Fedora Linux 43 (Workstation Edition) | 🎯 COPR | 👥 1 |
 | Fedora Linux 43 (KDE Plasma Desktop Edition) | 🎯 COPR | 👥 1 |
 <!-- STATS:TESTED_DISTROS:END -->
@@ -515,20 +518,20 @@ _Based on **113** unique users (**649** anonymous data points) — last updated 
 <!-- STATS:HEADSETS:START -->
 | Headset | Installs |
 |---|---|
-| Arctis Nova Pro Wireless | 37 |
+| Arctis Nova Pro Wireless | 44 |
 | Arctis Nova 7 (Gen 2) | 23 |
 | Arctis Pro Wireless | 7 |
-| Arctis Nova 3 | 6 |
 | Arctis Nova 7P (Gen 2) | 6 |
+| Arctis Nova 3 | 5 |
 | Arctis Nova 5 Wireless | 5 |
 | Arctis Nova 7 (Gen 1) | 5 |
 | Arctis Nova Pro Wired | 5 |
 | Arctis 7+ | 4 |
 | Arctis 7/Pro Gaming | 4 |
 | Arctis 9 Wireless | 3 |
+| Arctis GameBuds | 2 |
 | Arctis Nova Elite | 2 |
 | Arctis 1/7X/7P Wireless | 2 |
-| Arctis GameBuds | 1 |
 | Arctis GameBuds X | 1 |
 | Arctis Nova 5X (PID 2255) | 1 |
 | Arctis Nova Pro Omni | 1 |
@@ -537,8 +540,8 @@ _Based on **113** unique users (**649** anonymous data points) — last updated 
 <!-- STATS:DISTROS:START -->
 | Distribution | Installs |
 |---|---|
-| CachyOS | 56 |
-| Arch Linux | 14 |
+| CachyOS | 57 |
+| Arch Linux | 15 |
 | Nobara Linux 43 (KDE Plasma Desktop Edition) | 8 |
 | Ubuntu 26.04 LTS | 7 |
 | Garuda Linux | 5 |
@@ -546,12 +549,12 @@ _Based on **113** unique users (**649** anonymous data points) — last updated 
 | Ubuntu 24.04.4 LTS | 3 |
 | Linux Mint 22.3 | 3 |
 | Artix Linux | 3 |
+| SteamOS | 2 |
+| Pop!_OS 24.04 LTS | 2 |
 | Manjaro Linux | 2 |
 | EndeavourOS | 2 |
-| PikaOS 4 | 1 |
-| NixOS 26.05 (Yarara) | 1 |
-| Fedora Linux 44 (Workstation Edition) | 1 |
-| Fedora Linux 43 (Workstation Edition) | 1 |
+| SUSE Linux Enterprise Server for SAP Applications 12 SP2 | 1 |
+| Russian Nuclear Submarine Ballast Management Controller BMC (OpenBMC Project Reference Distro) 2.8.2-34 | 1 |
 <!-- STATS:DISTROS:END -->
 </details>
 

--- a/src/arctis_sound_manager/bug_reporter.py
+++ b/src/arctis_sound_manager/bug_reporter.py
@@ -8,6 +8,8 @@ No Qt imports: safe to use in daemon (headless).
 import json
 import os
 import platform
+import re
+import shutil
 import subprocess
 import sys
 import traceback
@@ -98,6 +100,84 @@ def _detect_install_methods() -> list[str]:
     return methods
 
 
+def _run_out(cmd: list[str], timeout: float = 5.0) -> str:
+    """Run *cmd* and return its stdout, stripped.
+
+    Returns '' when the binary is missing, the command times out, or it
+    raises. stdout is returned even on a non-zero exit code because tools
+    like `systemctl is-active` exit non-zero while still printing the state
+    ('inactive', 'failed') we want to report.
+    """
+    if not cmd or not shutil.which(cmd[0]):
+        return ''
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return r.stdout.strip()
+    except Exception:
+        return ''
+
+
+_ARCTIS_PATTERNS = ('arctis', '1038', 'steelseries')
+
+
+def _detect_container_env() -> str:
+    """Distrobox / Flatpak / Snap / docker / native detection.
+
+    Inside a Distrobox the daemon only reaches PipeWire through forwarded
+    sockets — knowing we are in a container is the first question a
+    maintainer asks when virtual outputs are missing (issue #74).
+    """
+    if os.environ.get('FLATPAK_ID'):
+        return f"flatpak (FLATPAK_ID={os.environ['FLATPAK_ID']})"
+    if os.environ.get('SNAP'):
+        return f"snap (SNAP={os.environ['SNAP']})"
+    container = os.environ.get('container', '')
+    if (container == 'distrobox'
+            or os.environ.get('DISTROBOX_ENTER_PATH')
+            or os.environ.get('CONTAINER_ID')):
+        name = os.environ.get('CONTAINER_ID', '?')
+        return f'distrobox (container={container or "?"}, CONTAINER_ID={name})'
+    if container:
+        return f'container ({container})'
+    if Path('/.dockerenv').exists():
+        return 'docker'
+    return 'native'
+
+
+def _arctis_pw_nodes() -> str:
+    """PipeWire objects matching the Arctis (node name, 'steelseries', or
+    vendor id 1038). Empty result while USB sees the device means PipeWire
+    never created the ALSA nodes — the issue #74 Distrobox failure mode.
+
+    Prefers `pw-dump`; falls back to `pactl list sinks` when pipewire-utils
+    is not installed.
+    """
+    if shutil.which('pw-dump'):
+        raw = _run_out(['pw-dump'], timeout=5.0)
+        try:
+            objects = json.loads(raw)
+        except Exception:
+            objects = None
+        if isinstance(objects, list):
+            lines = []
+            for obj in objects:
+                blob = json.dumps(obj).lower()
+                if not any(p in blob for p in _ARCTIS_PATTERNS):
+                    continue
+                props = (obj.get('info') or {}).get('props') or {}
+                lines.append(
+                    f"id={obj.get('id')} "
+                    f"name={props.get('node.name') or props.get('device.name', '?')} "
+                    f"class={props.get('media.class', '?')} "
+                    f"desc={props.get('node.description') or props.get('device.description', '')}"
+                )
+            return '\n'.join(lines)
+    raw = _run_out(['pactl', 'list', 'sinks'], timeout=5.0)
+    blocks = re.split(r'\n(?=Sink #)', raw)
+    kept = [b for b in blocks if any(p in b.lower() for p in _ARCTIS_PATTERNS)]
+    return '\n'.join(kept).strip()
+
+
 def collect_system_info() -> dict:
     info: dict = {}
 
@@ -180,6 +260,33 @@ def collect_system_info() -> dict:
     except Exception:
         info['wpctl'] = ''
 
+    # --- PipeWire runtime / container diagnostics (issue #74) ----------------
+    # When ASM runs inside Distrobox/Flatpak, PipeWire is only reachable
+    # through forwarded sockets. These fields show whether the sockets are
+    # actually passed through and whether PipeWire sees the headset at all.
+    info['pipewire_runtime_dir'] = os.environ.get('PIPEWIRE_RUNTIME_DIR', '<unset>')
+    info['pulse_server'] = os.environ.get('PULSE_SERVER', '<unset>')
+    info['container_env'] = _detect_container_env()
+
+    info['pw_sources'] = _run_out(['pactl', 'list', 'sources', 'short'])
+
+    info['filter_chain_status'] = (
+        _run_out(['systemctl', '--user', 'is-active', 'filter-chain']) or 'unknown'
+    )
+    info['pw_service_status'] = ' '.join(
+        f"{unit}={_run_out(['systemctl', '--user', 'is-active', unit]) or 'unknown'}"
+        for unit in ('pipewire', 'pipewire-pulse')
+    )
+
+    info['pw_arctis_nodes'] = _arctis_pw_nodes()
+
+    info['journalctl_pipewire'] = _run_out(
+        ['journalctl', '--user', '-u', 'pipewire', '-n', '20', '--no-pager'],
+    )
+    info['journalctl_filter_chain'] = _run_out(
+        ['journalctl', '--user', '-u', 'filter-chain', '-n', '30', '--no-pager'],
+    )
+
     # udev rules: which paths exist + the actual content of the active file.
     # The ASM checker's own verdict on whether the rules are valid is also useful.
     try:
@@ -233,6 +340,11 @@ def format_bug_report(traceback_str: Optional[str] = None) -> str:
         f'- **Desktop / Session**: {info.get("desktop", "?")} / {info.get("session_type", "?")}',
         f'- **D-Bus session**: `{info.get("dbus_session", "?")}`',
         f'- **USB monitor backend**: {info.get("usb_monitor_backend", "?")}',
+        f'- **Container environment**: {info.get("container_env", "?")}',
+        f'- **PIPEWIRE_RUNTIME_DIR**: `{info.get("pipewire_runtime_dir", "?")}`',
+        f'- **PULSE_SERVER**: `{info.get("pulse_server", "?")}`',
+        f'- **PipeWire services**: {info.get("pw_service_status", "?")}',
+        f'- **filter-chain.service**: {info.get("filter_chain_status", "?")}',
         '',
     ]
 
@@ -296,6 +408,29 @@ def format_bug_report(traceback_str: Optional[str] = None) -> str:
             '',
         ]
 
+    pw_sources = info.get('pw_sources', '')
+    if pw_sources:
+        lines += [
+            '## PipeWire sources',
+            '```',
+            pw_sources,
+            '```',
+            '',
+        ]
+
+    # Always shown: an EMPTY node list while USB sees the headset is exactly
+    # the signal that PipeWire never created the ALSA nodes (issue #74).
+    lines += [
+        '## PipeWire — Arctis nodes',
+        '<!-- Empty while the USB section above shows the headset = PipeWire',
+        '     does not see the device (common in Distrobox when the PipeWire',
+        '     sockets are not forwarded into the container). -->',
+        '```',
+        info.get('pw_arctis_nodes', '') or '(none — PipeWire does not see any Arctis node)',
+        '```',
+        '',
+    ]
+
     wpctl = info.get('wpctl', '')
     if wpctl:
         lines += [
@@ -326,6 +461,26 @@ def format_bug_report(traceback_str: Optional[str] = None) -> str:
             '## Recent daemon logs',
             '```',
             logs[-4000:],
+            '```',
+            '',
+        ]
+
+    jc_pw = info.get('journalctl_pipewire', '')
+    if jc_pw:
+        lines += [
+            '## PipeWire logs (`journalctl --user -u pipewire`, last 20)',
+            '```',
+            jc_pw[-3000:],
+            '```',
+            '',
+        ]
+
+    jc_fc = info.get('journalctl_filter_chain', '')
+    if jc_fc:
+        lines += [
+            '## filter-chain logs (`journalctl --user -u filter-chain`, last 30)',
+            '```',
+            jc_fc[-3000:],
             '```',
             '',
         ]
@@ -363,6 +518,7 @@ def format_bug_report_short(traceback_str: Optional[str] = None,
         f'- **PipeWire**: {info.get("pipewire", "unknown")}',
         f'- **Desktop / Session**: {info.get("desktop", "?")} / {info.get("session_type", "?")}',
         f'- **USB monitor backend**: {info.get("usb_monitor_backend", "?")}',
+        f'- **Container environment**: {info.get("container_env", "?")}',
         f'- **Install methods**: {", ".join(methods) or "?"}',
         '',
         '## Library versions',

--- a/src/arctis_sound_manager/diagnose.py
+++ b/src/arctis_sound_manager/diagnose.py
@@ -173,6 +173,129 @@ def _section_journalctl() -> str:
     return raw
 
 
+_ARCTIS_PATTERNS = ('arctis', '1038', 'steelseries')
+
+
+def _detect_container_env() -> str:
+    """Identify the sandbox/container ASM is running in, if any.
+
+    Distrobox is the interesting case for audio bugs (issue #74): the
+    container only sees PipeWire through forwarded sockets, so a wrong or
+    missing $PIPEWIRE_RUNTIME_DIR / $PULSE_SERVER silently breaks
+    _discover_physical_nodes().
+    """
+    if os.environ.get('FLATPAK_ID'):
+        return f"flatpak (FLATPAK_ID={os.environ['FLATPAK_ID']})"
+    if os.environ.get('SNAP'):
+        return f"snap (SNAP={os.environ['SNAP']})"
+    container = os.environ.get('container', '')
+    if (container == 'distrobox'
+            or os.environ.get('DISTROBOX_ENTER_PATH')
+            or os.environ.get('CONTAINER_ID')):
+        name = os.environ.get('CONTAINER_ID', '?')
+        return f'distrobox (container={container or "?"}, CONTAINER_ID={name})'
+    if container:
+        return f'container ({container})'
+    if Path('/.dockerenv').exists():
+        return 'docker'
+    return 'native'
+
+
+def _filter_arctis_blocks(raw: str, header_prefix: str) -> str:
+    """Keep only the `pactl list <kind>` blocks that mention an Arctis device
+    (by name or by SteelSeries vendor id 0x1038)."""
+    blocks = re.split(rf'\n(?={re.escape(header_prefix)} #)', raw)
+    kept = [b for b in blocks
+            if any(p in b.lower() for p in _ARCTIS_PATTERNS)]
+    return '\n'.join(kept).strip() or f'(no Arctis-related {header_prefix.lower()} found)'
+
+
+def _pw_dump_arctis() -> str:
+    """`pw-dump` filtered to Arctis/SteelSeries objects; falls back to
+    `pactl list sinks` when pw-dump is not installed."""
+    if shutil.which('pw-dump'):
+        raw = _run(['pw-dump'], timeout=5.0)
+        try:
+            objects = json.loads(raw)
+        except Exception as e:
+            return f'(pw-dump output not parseable: {e!r})'
+        lines = []
+        for obj in objects:
+            blob = json.dumps(obj).lower()
+            if not any(p in blob for p in _ARCTIS_PATTERNS):
+                continue
+            props = (obj.get('info') or {}).get('props') or {}
+            lines.append(
+                f"  id={obj.get('id')} type={obj.get('type', '?').rsplit(':', 1)[-1]} "
+                f"name={props.get('node.name') or props.get('device.name', '?')} "
+                f"class={props.get('media.class', '?')} "
+                f"desc={props.get('node.description') or props.get('device.description', '')}"
+            )
+        return ('pw-dump objects matching arctis/1038/steelseries:\n'
+                + ('\n'.join(lines) if lines else '  (none — PipeWire does not see the device!)'))
+    # Fallback for systems without pipewire-utils.
+    raw = _run(['pactl', 'list', 'sinks'], timeout=5.0)
+    return ('(pw-dump not in PATH — falling back to pactl list sinks, Arctis only)\n'
+            + _filter_arctis_blocks(raw, 'Sink'))
+
+
+def _section_pipewire_runtime() -> str:
+    """PipeWire runtime state — sockets, services, nodes, logs.
+
+    Targets the Distrobox failure mode of issue #74: the daemon attaches the
+    USB device fine, but PipeWire inside the container never exposes the ALSA
+    sinks, so loopback creation silently does nothing.
+    """
+    out = io.StringIO()
+
+    out.write('Environment:\n')
+    out.write(f'  container_env:        {_detect_container_env()}\n')
+    for var in ('PIPEWIRE_RUNTIME_DIR', 'PULSE_SERVER', 'PIPEWIRE_REMOTE',
+                'XDG_RUNTIME_DIR'):
+        out.write(f'  {var}: {os.environ.get(var, "<unset>")}\n')
+
+    out.write('\nUser services (systemctl --user is-active):\n')
+    if shutil.which('systemctl'):
+        for unit in ('pipewire', 'pipewire-pulse', 'wireplumber', 'filter-chain'):
+            state = _run(['systemctl', '--user', 'is-active', unit]).strip()
+            out.write(f'  {unit}: {state}\n')
+    else:
+        out.write('  (skipped: systemctl not in PATH)\n')
+
+    out.write('\n--- pactl list sinks short ---\n')
+    out.write(_run(['pactl', 'list', 'sinks', 'short']))
+
+    out.write('\n--- pactl list sources short (Arctis only) ---\n')
+    sources = _run(['pactl', 'list', 'sources', 'short'])
+    if 'skipped' in sources:
+        out.write(sources)
+    else:
+        arctis_sources = [l for l in sources.splitlines()
+                          if any(p in l.lower() for p in _ARCTIS_PATTERNS)]
+        out.write('\n'.join(arctis_sources) or '(no Arctis source)')
+
+    out.write('\n\n--- pactl list sinks (Arctis only, full) ---\n')
+    full_sinks = _run(['pactl', 'list', 'sinks'])
+    out.write(full_sinks if 'skipped' in full_sinks
+              else _filter_arctis_blocks(full_sinks, 'Sink'))
+
+    out.write('\n\n--- pw-dump (Arctis objects) ---\n')
+    out.write(_pw_dump_arctis())
+
+    out.write('\n\n--- wpctl status ---\n')
+    out.write(_run(['wpctl', 'status']))
+
+    out.write('\n\n--- journalctl --user -u pipewire (last 20) ---\n')
+    out.write(_run(['journalctl', '--user', '-u', 'pipewire',
+                    '-n', '20', '--no-pager'], timeout=5.0))
+
+    out.write('\n\n--- journalctl --user -u filter-chain (last 30) ---\n')
+    out.write(_run(['journalctl', '--user', '-u', 'filter-chain',
+                    '-n', '30', '--no-pager'], timeout=5.0))
+
+    return out.getvalue()
+
+
 def _section_settings() -> str:
     out = io.StringIO()
     settings_yaml = SETTINGS_FOLDER.parent / 'general_settings.yaml'
@@ -210,6 +333,7 @@ def diagnose(stream=sys.stdout) -> int:
         ('SteelSeries USB devices (vendor 0x1038)', _section_lsusb),
         ('udev rules', _section_udev),
         ('PulseAudio / PipeWire', _section_pulseaudio),
+        ('PipeWire runtime / container diagnostics', _section_pipewire_runtime),
         ('User device YAML overrides', _section_yamls),
         ('Settings (redacted)', _section_settings),
         ('Journalctl — arctis-manager.service (last 100 lines)', _section_journalctl),


### PR DESCRIPTION
## Why

In #74, a Distrobox user had no virtual outputs because `_discover_physical_nodes()` could not see the Arctis ALSA sinks from inside the container — the daemon log just stopped at "Detaching kernel driver". Neither `asm-cli diagnose` nor the GitHub bug report contained the data needed to triage this, forcing a multi-round-trip with the reporter.

## What

### `diagnose.py` — new section: *PipeWire runtime / container diagnostics*

- Container detection: Distrobox (`container=distrobox`, `CONTAINER_ID`, `DISTROBOX_ENTER_PATH`), Flatpak (`FLATPAK_ID`), Snap (`SNAP`), docker, native
- `$PIPEWIRE_RUNTIME_DIR`, `$PULSE_SERVER`, `$PIPEWIRE_REMOTE`, `$XDG_RUNTIME_DIR` — are the sockets actually forwarded into the container?
- `systemctl --user is-active` for `pipewire`, `pipewire-pulse`, `wireplumber`, `filter-chain`
- `pactl list sinks short` + full `pactl list sinks` blocks filtered to Arctis/1038/SteelSeries
- `pactl list sources short` filtered to Arctis
- `pw-dump` objects matching Arctis (id / node.name / media.class / description), with fallback to `pactl list sinks` when `pw-dump` is absent
- `wpctl status` (was in bug_reporter but missing from diagnose)
- `journalctl --user -u pipewire -n 20` and `-u filter-chain -n 30`

### `bug_reporter.py` — same data in `collect_system_info()` + `format_bug_report()`

New fields: `pipewire_runtime_dir`, `pulse_server`, `container_env`, `pw_sources`, `filter_chain_status`, `pw_service_status`, `pw_arctis_nodes`, `journalctl_pipewire`, `journalctl_filter_chain`.

The **PipeWire — Arctis nodes** section is rendered even when empty, because an empty node list while the USB section shows the headset is exactly the #74 signal. The compact (URL) report gains a single `Container environment` line.

## Robustness

- Every command goes through `_run()` / new `_run_out()` — `shutil.which()` check, 5 s timeout, missing tools degrade to `(skipped: ... not in PATH)` instead of failing
- `systemctl is-active` stdout is kept even on non-zero exit (it prints `inactive`/`failed`)
- No new dependencies — subprocess only
- Existing sections/fields untouched

## Testing

- `py_compile` clean on both files
- Unit-style smoke test: container detection (native/distrobox/flatpak), Arctis sink-block filtering, full + short report rendering with all new fields asserted present
- Full `_section_pipewire_runtime()` executed on a machine with none of the tools installed — all fallback paths produce readable `(skipped)` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)