### PR TITLE
fix(nix): declaratively replace asm-setup for module installs

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -131,6 +131,48 @@ in
           # ASM daemon restarts it by this exact name when applying EQ changes).
           filter-chain.wantedBy = [ "default.target" ];
 
+          # Reproduce the two per-user side effects of asm-setup that the rest of
+          # this module doesn't already cover declaratively — everything else
+          # (PipeWire EQ/surround configs, virtual sinks, device defs) the daemon
+          # regenerates itself at startup. Both writes are copy-if-absent, so a
+          # user who later customises either is never overwritten.
+          #
+          #   1. Default HeSuVi 7.1 HRIR. Nothing else creates
+          #      ~/.local/share/pipewire/hrir_hesuvi/hrir.wav: asm-setup (which
+          #      downloads it on regular distros) is deliberately not run here, the
+          #      daemon defaults hrir_id to null, and the GUI HRIR picker only
+          #      copies the tiny src/hrir_assets stubs. Without a valid 161 KB
+          #      impulse here the filter-chain has nothing to convolve and the
+          #      surround Game / Media channels are silent.
+          #
+          #   2. ~/.config/arctis_manager/.setup_done sentinel. The tray GUI runs
+          #      asm-setup automatically (FirstRunDialog, incl. a pkexec prompt)
+          #      whenever this flag is missing — exactly what a module install is
+          #      meant to make unnecessary. Marking setup done suppresses only that
+          #      auto-run; the GUI's independent udev check still surfaces real
+          #      rule problems.
+          arctis-firstrun-seed = {
+            description = "Seed default Arctis HRIR + mark setup done (if absent)";
+            wantedBy = [ "default.target" ];
+            before = [
+              "filter-chain.service"
+              "arctis-manager.service"
+            ];
+            path = [ pkgs.coreutils ];
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+            };
+            script = ''
+              dest="$HOME/.local/share/pipewire/hrir_hesuvi/hrir.wav"
+              [ -e "$dest" ] || install -Dm644 \
+                ${cfg.package}/share/arctis-sound-manager/hrir/EAC_Default.wav "$dest"
+
+              flag="$HOME/.config/arctis_manager/.setup_done"
+              [ -e "$flag" ] || { mkdir -p "$(dirname "$flag")"; : > "$flag"; }
+            '';
+          };
+
           arctis-manager = userService {
             description = "Arctis Sound Manager device daemon";
             after = [

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -26,9 +26,16 @@
 
 let
   # Only the files the wheel + packaging steps need. Keeps the build input small
-  # and avoids rebuilds when unrelated repo files (docs, top-level hrir/, aur/…)
-  # change. The 58 selectable HRIR profiles live under src/.../hrir_assets and
-  # are included via ../src.
+  # and avoids rebuilds when unrelated repo files (docs, rest of top-level hrir/,
+  # aur/…) change. The 58 selectable HRIR profiles live under src/.../hrir_assets
+  # and are included via ../src.
+  #
+  # ../hrir/EAC_Default.wav is the real 161 KB HeSuVi 7.1 default impulse response
+  # that `asm-setup` downloads on regular distros. We ship it in the closure so the
+  # NixOS module can seed it as the active hrir.wav (see module.nix) — without it,
+  # surround Game/Media channels are silent on a module-only install, because the
+  # GUI HRIR picker only copies the tiny src/hrir_assets stubs and the module never
+  # runs asm-setup. The other selectable profiles stay download-on-demand.
   src = lib.fileset.toSource {
     root = ../.;
     fileset = lib.fileset.unions [
@@ -37,6 +44,7 @@ let
       ../LICENSE
       ../src
       ../scripts/generate_udev_rules.py
+      ../hrir/EAC_Default.wav
     ];
   };
 
@@ -169,6 +177,12 @@ python3Packages.buildPythonApplication {
       --replace-fail "Exec=asm-gui" "Exec=$out/bin/asm-gui"
     install -Dm644 src/arctis_sound_manager/gui/images/steelseries_logo.svg \
       "$out/share/icons/hicolor/scalable/apps/arctis-manager.svg"
+
+    # Default HeSuVi 7.1 HRIR. The NixOS module copies this into each user's
+    # ~/.local/share/pipewire/hrir_hesuvi/hrir.wav (only if absent), giving
+    # working surround out of the box without asm-setup or a network download.
+    install -Dm644 hrir/EAC_Default.wav \
+      "$out/share/arctis-sound-manager/hrir/EAC_Default.wav"
   '';
 
   passthru.updateScript = null;


### PR DESCRIPTION
A NixOS-module-only install (services.arctis-sound-manager.enable) is meant to need no asm-setup, but two per-user side effects of asm-setup were never reproduced declaratively, so the module wasn't self-sufficient:

  1. The default HeSuVi 7.1 HRIR. Nothing creates ~/.local/share/pipewire/hrir_hesuvi/hrir.wav on this path: asm-setup (which downloads the 161 KB EAC_Default.wav on regular distros) is deliberately not run, the daemon defaults hrir_id to null, and the GUI HRIR picker (apply_hrir_choice) only copies the tiny src/hrir_assets stubs with no size check or download fallback. So the daemon-generated filter-chain convolves against nothing and the surround Game / Media channels are silent. (The #79 _hrir_valid()
     >10 KB fix lives only in scripts/setup.py, which module users never
     run, so it does not help this path.)

  2. The ~/.config/arctis_manager/.setup_done sentinel. The tray GUI runs asm-setup automatically (FirstRunDialog, including a pkexec prompt) whenever this flag is missing — the exact flow a module install is supposed to make unnecessary, and on NixOS it is the fragile #79 path.

Everything else asm-setup does (PipeWire EQ/surround configs, virtual sinks, device defs) the daemon regenerates itself at startup, so only these two writes were missing.

  - package.nix: add ../hrir/EAC_Default.wav to the build fileset and install it to $out/share/arctis-sound-manager/hrir/.
  - module.nix: add an arctis-firstrun-seed oneshot user service that, only if absent, installs the HRIR into hrir_hesuvi/hrir.wav and touches .setup_done (ordered before filter-chain/arctis-manager). Copy-if-absent never overwrites a user-customised HRIR or a real setup run; marking setup done suppresses only the auto-run, not the GUI's udev check.

No network, no asm-setup; a fresh enable now gives working surround and a clean first launch out of the box.