### PR TITLE
Align test suite with current implementation

### DIFF
--- a/tests/test_boot_rescan.py
+++ b/tests/test_boot_rescan.py
@@ -32,6 +32,7 @@ def _make_engine_stub():
 
     engine = CoreEngine.__new__(CoreEngine)
     engine.logger = MagicMock()
+    engine.pa_audio_manager = MagicMock()
     engine._device_lock = threading.RLock()
     engine._detect_lock = threading.Lock()
     engine._device_ready = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,7 +19,7 @@ def test_config_parse():
 
     assert config.name == "SteelSeries Arctis Nova Pro Wireless"
     assert config.vendor_id == 0x1038
-    assert config.product_ids == [0x12e0, 0x12e5]
+    assert config.product_ids == [0x12e0, 0x12e5, 0x225d]
 
     assert config.command_interface_index == [4, 0]
     assert config.listen_interface_indexes == [4]
@@ -33,21 +33,21 @@ def test_config_parse():
 
     assert config.status is not None
     assert config.status.request == 0x06b0
-    assert len(config.status.response_mapping) == 6
+    assert len(config.status.response_mapping) == 8
     assert config.status.response_mapping[0].starts_with == 0x0725
     assert config.status.response_mapping[1].starts_with == 0x0731
-    assert config.status.response_mapping[2].starts_with == 0x0745
-    assert config.status.response_mapping[5].starts_with == 0x06b0
+    assert config.status.response_mapping[3].starts_with == 0x0745
+    assert config.status.response_mapping[7].starts_with == 0x06b0
     assert len(config.status.response_mapping[0].__dict__.keys()) == 2
     assert len(config.status.response_mapping[1].__dict__.keys()) == 3
-    assert len(config.status.response_mapping[2].__dict__.keys()) == 3
-    assert len(config.status.response_mapping[5].__dict__.keys()) == 15
-    assert hasattr(config.status.response_mapping[5], 'headset_power_status')
+    assert len(config.status.response_mapping[3].__dict__.keys()) == 3
+    assert len(config.status.response_mapping[7].__dict__.keys()) == 15
+    assert hasattr(config.status.response_mapping[7], 'headset_power_status')
     assert len(config.status.representation.keys()) == 5
     assert list(config.status.representation.keys()) == ['headset', 'mic', 'gamedac', 'bluetooth', 'wireless']
-    assert config.status.representation['gamedac'] == ['station_volume', 'charge_slot_battery_charge']
+    assert config.status.representation['gamedac'] == ['station_volume', 'charge_slot_battery_charge', 'line_out']
 
-    assert len(config.status_parse) == 17
+    assert len(config.status_parse) == 18
     assert config.status_parse.get('bluetooth_power_status') is not None
     assert config.status_parse['bluetooth_power_status'].type == StatusParseType.ON_OFF
     assert config.status_parse['bluetooth_power_status'].init_kwargs == {'off': 0x01, 'on': 0x00}
@@ -65,11 +65,12 @@ def test_config_parse():
 
     assert config.settings is not None
 
-    assert len(config.settings) == 5
+    assert len(config.settings) == 6
     assert 'headset' in config.settings
     assert 'microphone' in config.settings
     assert 'power_management' in config.settings
     assert 'wireless' in config.settings
+    assert 'station' in config.settings
     assert 'audio' in config.settings
 
     assert len(config.settings['headset']) == 1

--- a/tests/test_redirect_audio.py
+++ b/tests/test_redirect_audio.py
@@ -147,7 +147,7 @@ def test_redirect_audio_unknown_sink_logs_error_and_skips():
     pa.sink_list_wrapper = MagicMock(return_value=[])
     pa.redirect_audio('nope')
     pa.pulse.default_set.assert_not_called()
-    pa.logger.error.assert_called()
+    pa.logger.warning.assert_called()
 
 
 def test_redirect_audio_writes_pw_metadata_when_available():

--- a/tests/test_sonar_to_pipewire.py
+++ b/tests/test_sonar_to_pipewire.py
@@ -149,7 +149,7 @@ def test_bypass_micro_has_node_name_in_playback():
     text = generate_sonar_micro_conf([], 0.0, 0.0, 0.0,
                                      output_path=Path("/dev/null"),
                                      boost_db=0.0)
-    assert 'node.name      = "effect_output.sonar-micro-eq"' in text
+    assert 'node.name             = "effect_output.sonar-micro-eq"' in text
 
 
 def test_active_game_has_node_name_in_playback():
@@ -177,7 +177,7 @@ def test_micro_source_pattern():
     # Capture side: passive, no media.class
     assert "node.passive   = true" in text
     # Playback side: Audio/Source (not Audio/Source/Virtual)
-    assert "media.class    = Audio/Source" in text
+    assert "media.class           = Audio/Source" in text
     assert "Audio/Source/Virtual" not in text
     # No Audio/Sink on capture side
     assert "Audio/Sink" not in text
@@ -308,7 +308,7 @@ def test_check_and_fix_stale_configs_fixes_micro_source_virtual(tmp_path):
 
     fixed = (tmp_path / "sonar-micro-eq.conf").read_text()
     assert "Audio/Source/Virtual" not in fixed
-    assert "media.class    = Audio/Source" in fixed
+    assert "media.class           = Audio/Source" in fixed
 
 
 # ── generate_virtual_sinks_conf — deprecated shim behaviour ──────────────────

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "arctis-sound-manager"
-version = "1.1.74"
+version = "1.1.79"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
I have updated the test suite to align it with the current application implementation. Several tests were failing because the source code (including device configurations and core engine logic) had evolved beyond the existing test assertions. 

Key changes include:
1.  **Mocking `pa_audio_manager`**: Fixed an `AttributeError` in `test_boot_rescan.py` by ensuring the mocked engine has the required audio manager attribute.
2.  **Configuration Alignment**: Updated `test_config.py` to reflect recent additions to `nova_pro_wireless.yaml`, such as support for the new Arctis Nova Pro Wireless X variant (`0x225d`), the `line_out` status mapping, and the `station` settings category.
3.  **Log Level Adjustment**: Changed a test assertion in `test_redirect_audio.py` from `error` to `warning` to match the actual implementation in `pactl.py`.
4.  **Whitespace Formatting**: Corrected exact string matches in `test_sonar_to_pipewire.py` to account for current indentation in generated PipeWire configurations.

All 487 tests now pass successfully (with expected skips).

---
*PR created automatically by Jules for task [15831038227402971089](https://jules.google.com/task/15831038227402971089) started by @loteran*