### PR TITLE
fix(update): dedupe asm-daemon PATH hits so usr-merge isn't a phantom install (#114)

### DIFF
--- a/src/arctis_sound_manager/bug_reporter.py
+++ b/src/arctis_sound_manager/bug_reporter.py
@@ -86,15 +86,20 @@ def _detect_install_methods() -> list[str]:
             pass
 
     # Every asm-daemon binary in PATH (catches pip --user installs that
-    # don't show up in any package manager).
+    # don't show up in any package manager). Canonicalise each hit before
+    # counting: on usr-merged distros /bin is a symlink to /usr/bin and both
+    # are on PATH, so `command -v -a` lists the same physical binary twice.
+    # Reporting that as a duplicate would send users chasing a nonexistent
+    # second install (issue #114) — dedupe by resolved path first.
     try:
         r = subprocess.run(
             ['bash', '-c', 'command -v -a asm-daemon'],
             capture_output=True, text=True, timeout=2,
         )
         bins = [b for b in r.stdout.strip().splitlines() if b]
-        if len(bins) > 1:
-            methods.append(f'asm-daemon binaries in PATH: {bins}')
+        distinct = sorted({os.path.realpath(b) for b in bins})
+        if len(distinct) > 1:
+            methods.append(f'asm-daemon binaries in PATH: {distinct}')
     except Exception:
         pass
     return methods

--- a/src/arctis_sound_manager/update_checker.py
+++ b/src/arctis_sound_manager/update_checker.py
@@ -75,14 +75,26 @@ def detect_all_install_methods() -> list[InstallMethod]:
         _user_site = Path(site.getusersitepackages()).resolve()
         _pip_user_detected = running_path.is_relative_to(_user_site)
 
-        # Signal 2 — multiple asm-daemon binaries on PATH
+        # Signal 2 — multiple *distinct* asm-daemon binaries on PATH.
+        # We must canonicalise each hit before counting: on usr-merged distros
+        # (all modern Ubuntu/Fedora/Arch) /bin is a symlink to /usr/bin and both
+        # are on PATH, so `command -v -a` lists the SAME physical binary twice
+        # (/usr/bin/asm-daemon and /bin/asm-daemon). Counting raw lines flags a
+        # phantom "second install" and blocks the update with a "Multiple ASM
+        # installations detected" banner (issue #114). Resolve symlinks and
+        # dedupe so only genuinely separate binaries count.
         if not _pip_user_detected:
             try:
                 r2 = subprocess.run(
                     ["bash", "-c", "command -v -a asm-daemon 2>/dev/null"],
                     capture_output=True, text=True, timeout=5,
                 )
-                _pip_user_detected = r2.stdout.count("\n") > 1
+                real_bins = {
+                    str(Path(ln.strip()).resolve())
+                    for ln in r2.stdout.splitlines()
+                    if ln.strip()
+                }
+                _pip_user_detected = len(real_bins) > 1
             except Exception:
                 pass
 

--- a/tests/test_update_checker.py
+++ b/tests/test_update_checker.py
@@ -122,6 +122,63 @@ def test_detect_pip_user_shadow_via_multiple_daemon_binaries(tmp_path):
     )
 
 
+def test_usrmerge_symlink_not_flagged_as_second_install(tmp_path):
+    """A single binary seen through /bin AND /usr/bin (usr-merge) is NOT a dup.
+
+    On modern Ubuntu/Fedora/Arch /bin is a symlink to /usr/bin and both are on
+    PATH, so `command -v -a asm-daemon` lists the same physical file twice
+    (/usr/bin/asm-daemon and /bin/asm-daemon). Before the fix this counted as a
+    second install and raised a phantom "Multiple ASM installations detected"
+    banner that blocked the update (issue #114).
+    """
+    # Simulate usr-merge: <root>/usr/bin/asm-daemon is the real file,
+    # <root>/bin is a symlink to <root>/usr/bin.
+    usr_bin = tmp_path / "usr" / "bin"
+    usr_bin.mkdir(parents=True)
+    real_daemon = usr_bin / "asm-daemon"
+    real_daemon.touch()
+    try:
+        (tmp_path / "bin").symlink_to(usr_bin, target_is_directory=True)
+    except (OSError, NotImplementedError):
+        pytest.skip("symlinks not supported on this platform/privilege level")
+
+    # Package NOT under user-site (signal 1 must not fire)
+    sys_site = tmp_path / "sys_site"
+    pkg_dir = sys_site / "arctis_sound_manager"
+    pkg_dir.mkdir(parents=True)
+    fake_init = pkg_dir / "__init__.py"
+    fake_init.touch()
+
+    user_site = tmp_path / "user_site"
+    user_site.mkdir(parents=True)
+
+    fake_asm = types.ModuleType("arctis_sound_manager")
+    fake_asm.__file__ = str(fake_init)
+
+    def _run_side(cmd, **kwargs):
+        if cmd[0] == "dpkg":
+            return _ok()  # apt install present
+        if cmd[:2] == ["bash", "-c"]:
+            # Same binary, two PATH spellings via the /bin -> /usr/bin symlink
+            return _ok(stdout=f"{tmp_path / 'usr' / 'bin' / 'asm-daemon'}\n"
+                              f"{tmp_path / 'bin' / 'asm-daemon'}\n")
+        return _fail()
+
+    with (
+        mock.patch.dict("sys.modules", {"arctis_sound_manager": fake_asm}),
+        mock.patch("site.getusersitepackages", return_value=str(user_site)),
+        mock.patch("shutil.which", side_effect=lambda b: None),
+        mock.patch("subprocess.run", side_effect=_run_side),
+    ):
+        result = detect_all_install_methods()
+
+    assert InstallMethod.APT in result
+    assert InstallMethod.PIP not in result, (
+        "usr-merge /bin symlink must not be counted as a second (pip) install"
+    )
+    assert len(result) == 1
+
+
 def test_detect_no_pip_shadow_clean_rpm_install(tmp_path):
     """When RPM is installed and no pip shadow exists, only RPM is returned."""
     sys_site = tmp_path / "sys_site"


### PR DESCRIPTION
## Problem (issue #114)

On usr-merged distros (all modern Ubuntu/Fedora/Arch) `/bin` is a symlink to `/usr/bin` and **both are on `PATH`**, so `command -v -a asm-daemon` lists the single installed binary twice (`/usr/bin/asm-daemon` **and** `/bin/asm-daemon`).

The pip-shadow heuristic counted raw output lines, so one clean install looked like two:
- the GUI showed **"Multiple ASM installations detected"** and hid the *Update now* button;
- users went hunting for a second copy that doesn't exist (the `.deb` only ever installs `asm-daemon` into `/usr/bin`, see `debian/rules:47`).

## Fix

Canonicalise every hit (resolve symlinks + normalise) and count **distinct real paths**, in both:
- `update_checker.detect_all_install_methods()` — signal 2 (drives the banner / updater block);
- `bug_reporter._detect_install_methods()` — the install-method line in bug reports.

Genuine dual installs (system package + `pip --user` shadow) are still detected.

## Test

Added `tests/test_update_checker.py::test_usrmerge_symlink_not_flagged_as_second_install`: a single binary reachable via a real `/bin -> /usr/bin` symlink is **not** flagged as a second install; skips where symlinks aren't permitted. Existing genuine-dual-install tests still pass.

> Note: the *other* half of #114 (Ubuntu 26.04 `apt` stuck on 1.1.90) is a separate infra issue — the `resolute` Launchpad build of 1.1.91 failed and needs a rebuild; not addressed by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)