### PR TITLE
fix(audio): never let the microphone chain be fed by an output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The microphone chain could be fed by the headset's own output — and other people heard it.** On an Arctis Nova 7 sitting on an `iec958-stereo` profile the headset exposes no capture node of its own, and the microphone slot fell back to the *output* sink. That sink's monitor was then linked into the microphone EQ, so everything audible on the machine — a browser tab, the game — was transmitted as if it were the microphone: a video played in a browser went out over a Discord call as though the user were speaking it. It came back on every daemon restart, which is why it reappeared with each update. The input no longer inherits the output's fallback, and the capture link is now refused outright when the proposed source is a sink. This is the one input-side mistake that is completely inaudible to the person making it.
+
 ## [1.2.19] - 30 July 2026
 
 ### Fixed

--- a/src/arctis_sound_manager/core.py
+++ b/src/arctis_sound_manager/core.py
@@ -1432,10 +1432,19 @@ class CoreEngine:
                 return
 
             fallback = physical_out_game or physical_out_chat or ""
+            # The input deliberately does NOT share the output's fallback.
+            # A headset with no capture node of its own — a Nova 7 sitting on
+            # an iec958-stereo profile, a wireless dongle whose mic has not
+            # enumerated yet — used to have its *sink* name stored as the mic,
+            # and ensure_micro_capture_link then wired that sink's monitor into
+            # effect_input.sonar-micro-eq. Everything the user could hear was
+            # transmitted as their microphone: a browser tab went out over
+            # Discord as if they were speaking it. Empty is the honest answer;
+            # the watchdog links the mic once a real source appears.
             device_state.set_current_device(
                 physical_out_game=physical_out_game or fallback,
                 physical_out_chat=physical_out_chat or fallback,
-                physical_in=physical_in or fallback,
+                physical_in=physical_in or "",
                 spatial_engine=device_config.spatial_engine,
                 device_name=device_config.name,
             )

--- a/src/arctis_sound_manager/pw_utils.py
+++ b/src/arctis_sound_manager/pw_utils.py
@@ -861,6 +861,7 @@ def ensure_capture_link(
             data = _pw_dump()
 
         node_ids: dict[str, int] = {}
+        node_classes: dict[str, str] = {}
         for obj in data:
             if not obj.get("type", "").endswith("Node"):
                 continue
@@ -868,11 +869,25 @@ def ensure_capture_link(
             name = props.get("node.name", "")
             if name:
                 node_ids[name] = obj["id"]
+                node_classes[name] = props.get("media.class", "")
 
         source_id = node_ids.get(source_name)
         capture_id = node_ids.get(capture_name)
         if source_id is None:
             logger.debug("ensure_capture_link: source '%s' not in graph", source_name)
+            return False
+
+        # A sink's "output" ports are its monitor: linking one here does not
+        # feed the microphone chain with a microphone, it feeds it with
+        # everything the user is listening to, and every app reading the ASM
+        # mic then transmits their desktop audio. Refused outright rather than
+        # trusted to the callers — this is the one mistake on the input side
+        # that is inaudible to the person making it.
+        if node_classes.get(source_name, "") == "Audio/Sink":
+            logger.error(
+                "ensure_capture_link: refusing to feed '%s' from '%s' — that is "
+                "an output, and its monitor would be transmitted as the "
+                "microphone", capture_name, source_name)
             return False
         if capture_id is None:
             logger.debug("ensure_capture_link: capture '%s' not in graph", capture_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,9 +3,162 @@
 
 """Suite-wide test safety nets."""
 
+import os
+import shlex
+import subprocess
 from pathlib import Path
 
 import pytest
+
+# Everything that can reach into the live audio graph. Read-only calls are
+# included deliberately: a unit test that shells out to the running server is
+# reading the developer's machine rather than its own fixture, which is how
+# tests come to pass or fail for reasons that have nothing to do with the code.
+#
+# The service managers are here for the worst case of the lot. Restarting
+# pipewire/wireplumber re-enumerates every ALSA device: each physical sink and
+# source is destroyed and rebuilt under a new node id, every stream on them is
+# interrupted, and the user is left with their sound in pieces — from a test
+# run that reported nothing but passes.
+_AUDIO_TOOLS = frozenset({
+    "pactl", "pacmd", "pasuspender", "wpctl", "pw-cli", "pw-metadata",
+    "pw-link", "pw-loopback", "pw-cat", "pw-play", "pw-record", "pw-dump",
+    "amixer", "alsactl",
+    "systemctl", "dinitctl", "service", "pipewire", "pipewire-pulse",
+    "wireplumber", "pulseaudio", "pkill", "killall",
+})
+
+
+def _audio_tool(args, shell: bool) -> str | None:
+    """The audio or service binary *args* would run, if any.
+
+    Every token is checked, not just the first: the real calls are wrapped
+    (``setsid systemctl …``, ``sh -c "sleep 2 && systemctl --user restart …"``)
+    and looking only at argv[0] would wave both of those straight through.
+    """
+    if isinstance(args, (str, bytes, os.PathLike)):
+        args = [args]
+    tokens: list[str] = []
+    for arg in args:
+        text = os.fsdecode(arg) if isinstance(arg, (bytes, os.PathLike)) else str(arg)
+        if shell or " " in text:
+            try:
+                tokens.extend(shlex.split(text))
+            except ValueError:
+                tokens.extend(text.split())
+        else:
+            tokens.append(text)
+    for token in tokens:
+        name = os.path.basename(token)
+        if name in _AUDIO_TOOLS:
+            return name
+    return None
+
+
+def pytest_configure(config):
+    """Give the whole suite a throwaway HOME before any test module imports.
+
+    Half of this package's paths are module-level constants built from
+    ``Path.home()`` — ``settings.json``, ``channel_volumes.json``,
+    ``eq_bands.json``, ``output_preference.json``, the filter-chain drop-ins.
+    They are resolved at *import* time, so a fixture cannot move them after the
+    fact; by the time one runs, the constant already points at the developer's
+    real configuration. Any test that writes through one of those constants
+    rewrites the live setup of whoever ran the suite, and the running daemon
+    picks the change up on its own — which is how a test run ends with the
+    sound genuinely broken and no failure to show for it.
+
+    Doing it in ``pytest_configure`` is what makes it work: conftest is
+    imported before test modules are collected, so every ``Path.home()``
+    evaluated during collection sees the temporary directory.
+
+    ``ASM_TEST_REAL_HOME`` keeps the original around for the rare test that
+    needs to know what a real home looks like.
+    """
+    import tempfile
+
+    config.addinivalue_line(
+        "markers",
+        "live_spawn: this test must spawn a real process to observe how it was "
+        "spawned (issue #123's posix_spawn-vs-fork guards), so the live-audio "
+        "Popen block is lifted for it. Only for commands that read and change "
+        "nothing — 'systemctl show', '--version'. Never for anything that "
+        "moves a sink, a link or a service.",
+    )
+
+    real_home = os.path.expanduser("~")
+    fake_home = tempfile.mkdtemp(prefix="asm-test-home-")
+    os.environ["ASM_TEST_REAL_HOME"] = real_home
+    os.environ["HOME"] = fake_home
+    for name, sub in (("XDG_CONFIG_HOME", ".config"),
+                      ("XDG_DATA_HOME", ".local/share"),
+                      ("XDG_STATE_HOME", ".local/state"),
+                      ("XDG_CACHE_HOME", ".cache")):
+        path = os.path.join(fake_home, *sub.split("/"))
+        os.makedirs(path, exist_ok=True)
+        os.environ[name] = path
+
+
+@pytest.fixture(autouse=True)
+def _no_live_audio_commands_suitewide(monkeypatch, request):
+    """Refuse to run pactl/pw-* against the developer's own sound server.
+
+    The suite runs on machines with a *live* ASM daemon, and its subjects are
+    the very functions that move default sinks, destroy nodes, relink ports and
+    respawn loopbacks. A test that reaches one of those for real does not fail
+    — it succeeds, against the developer's audio, and leaves them with their
+    sound broken and nothing in the output saying why.
+
+    Blocking at ``Popen`` covers ``run``/``check_output``/``call`` in one
+    place, since all of them go through it. Tests that mean to exercise a
+    command patch ``subprocess.run`` (or the module's own reference) and never
+    reach this; anything that trips it is a test talking to the real system,
+    which is the bug being reported here rather than an inconvenience.
+    """
+    if request.node.get_closest_marker("live_spawn") is not None:
+        # The spawn-path guards cannot be satisfied by a mock: what they assert
+        # is which syscall CPython used to start the process, which only exists
+        # if a process is really started. They are held to read-only commands
+        # and skip themselves when the binary is absent.
+        yield
+        return
+
+    real_popen = subprocess.Popen
+
+    class _GuardedPopen(real_popen):
+        def __init__(self, args, *rest, **kwargs):
+            tool = _audio_tool(args, bool(kwargs.get("shell")))
+            if tool is not None:
+                raise AssertionError(
+                    f"the test suite tried to run {tool!r} against the live "
+                    f"audio server: {args!r}. Mock the call — running it for "
+                    f"real rewrites the routing of whoever runs the tests.")
+            super().__init__(args, *rest, **kwargs)
+
+    monkeypatch.setattr(subprocess, "Popen", _GuardedPopen)
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _no_live_pulse_connection_suitewide(monkeypatch):
+    """Same rule for pulsectl: no test opens a socket to the real server.
+
+    ``pulsectl.Pulse`` is how volumes are set and streams are moved, and a
+    connection made in a test is a connection to the machine running it.
+    """
+    try:
+        import pulsectl
+    except ImportError:
+        return
+
+    def _refuse(*_args, **_kwargs):
+        raise AssertionError(
+            "the test suite tried to open a real pulsectl connection. Patch "
+            "pulsectl.Pulse — a live connection reads and writes the "
+            "developer's own audio server.")
+
+    monkeypatch.setattr(pulsectl, "Pulse", _refuse)
+    yield
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_mic_never_fed_by_an_output.py
+++ b/tests/test_mic_never_fed_by_an_output.py
@@ -1,0 +1,100 @@
+# Copyright (C) 2026 loteran
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""The microphone chain must never be fed by an output.
+
+Observed on a Nova 7 Gen 2 sitting on an iec958-stereo profile, which exposes
+no capture node of its own: the daemon stored the *sink* name as the device's
+microphone (``physical_in or fallback``, where the fallback was the output),
+and ensure_micro_capture_link then linked that sink's monitor into
+``effect_input.sonar-micro-eq``. Everything the user could hear went out as
+their microphone — a browser tab played over Discord as if they were speaking
+it — with nothing in the UI or the log saying so.
+
+Two independent guards are pinned here, because the failure is silent to the
+person making it: the daemon must not store an output as the mic, and the link
+layer must refuse one even if something else asks.
+"""
+from __future__ import annotations
+
+import pytest
+
+from arctis_sound_manager import pw_utils
+
+SINK = "alsa_output.usb-SteelSeries_Arctis_Nova_7-00.iec958-stereo"
+MIC = "alsa_input.usb-HP__Inc_HyperX_DuoCast_202011110001-00.analog-stereo"
+CAPTURE = "effect_input.sonar-micro-eq"
+
+
+def _node(node_id: int, name: str, media_class: str) -> dict:
+    return {"id": node_id, "type": "PipeWire:Interface:Node",
+            "info": {"props": {"node.name": name, "media.class": media_class}}}
+
+
+def _port(port_id: int, node_id: int, direction: str, channel: str) -> dict:
+    return {"id": port_id, "type": "PipeWire:Interface:Port",
+            "info": {"props": {"port.direction": direction,
+                               "node.id": node_id,
+                               "audio.channel": channel,
+                               "port.name": f"{direction}_{channel}"}}}
+
+
+@pytest.fixture
+def graph():
+    """A sink, a real microphone, and the ASM mic-EQ capture node."""
+    return [
+        _node(101, SINK, "Audio/Sink"),
+        _port(1011, 101, "out", "FL"),      # the sink's monitor
+        _port(1012, 101, "out", "FR"),
+        _node(100, MIC, "Audio/Source"),
+        _port(1001, 100, "out", "FL"),
+        _port(1002, 100, "out", "FR"),
+        _node(200, CAPTURE, "Stream/Input/Audio"),
+        _port(2001, 200, "in", "FL"),
+        _port(2002, 200, "in", "FR"),
+    ]
+
+
+# ── the link layer ────────────────────────────────────────────────────────────
+
+@pytest.fixture
+def pw_calls(monkeypatch):
+    """Record what would have been run against the graph, and run nothing."""
+    import types
+
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return types.SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(pw_utils, "_pw_run", fake_run)
+    return calls
+
+
+def test_a_sink_is_refused_as_a_microphone(graph, pw_calls):
+    """Its output ports are its monitor — this is desktop audio, not a mic."""
+    assert pw_utils.ensure_capture_link(SINK, CAPTURE, data=graph) is False
+    assert pw_calls == []
+
+
+def test_a_real_microphone_is_still_linked(graph, pw_calls):
+    """The guard must not cost the feature it protects."""
+    assert pw_utils.ensure_capture_link(MIC, CAPTURE, data=graph) is True
+    assert len([c for c in pw_calls if "-d" not in c]) == 2
+
+
+# ── the daemon's device state ─────────────────────────────────────────────────
+
+def test_a_headset_with_no_capture_node_reports_no_microphone():
+    """The daemon used to fall back to the output here. Empty is the honest
+    answer: the watchdog links the mic when a real source turns up."""
+    import inspect
+
+    from arctis_sound_manager import core
+
+    source = inspect.getsource(core.CoreEngine)
+    assert "physical_in=physical_in or fallback" not in source, (
+        "physical_in must not fall back to the output sink — that is what fed "
+        "the microphone chain with the headset's monitor")
+    assert 'physical_in=physical_in or ""' in source

--- a/tests/test_sonar_to_pipewire.py
+++ b/tests/test_sonar_to_pipewire.py
@@ -816,8 +816,11 @@ def test_ensure_filter_chain_healthy_returns_true_when_healthy(tmp_path, monkeyp
     (tmp_path / "sonar-game-eq.conf").write_text("# dummy ASM conf")
 
     with patch("arctis_sound_manager.service_control.is_active", return_value=True), \
-         patch("arctis_sound_manager.init_system.detect_init", return_value="unknown"):
+         patch("arctis_sound_manager.service_control.detect_init",
+               return_value="unknown"):
         # detect_init returning "unknown" skips NRestarts check
+        # (service_control binds detect_init at import, so it must be patched
+        # there — patching init_system leaves the real systemctl call in place)
         result = stp.ensure_filter_chain_healthy()
 
     assert result is True
@@ -1418,6 +1421,12 @@ def test_ensure_spatial_eq_links_moves_link_on_toggle(monkeypatch):
     state = {"game": True}
     monkeypatch.setattr(_s2p_p3, "_spatial_enabled", lambda ch: state[ch])
     monkeypatch.setattr(_s2p_p3, "_get_physical_out_game", lambda: "alsa_output.test-headset")
+    # HeSuVi is loaded — otherwise the issue #100 fallback sends the ON legs to
+    # the physical output too, and the toggle it is testing stops being visible.
+    monkeypatch.setattr(
+        "arctis_sound_manager.pw_utils.pw_node_exists",
+        lambda name, data=None: True,
+    )
     targets = []
     monkeypatch.setattr(
         "arctis_sound_manager.pw_utils.ensure_loopback_link",

--- a/tests/test_spawn_no_fork.py
+++ b/tests/test_spawn_no_fork.py
@@ -78,6 +78,7 @@ def test_service_control_run_uses_posix_spawn_not_fork():
     assert spy.hits == {"posix_spawn": 1, "fork_exec": 0}
 
 
+@pytest.mark.live_spawn  # 'systemctl show -p NRestarts' — reads, changes nothing
 def test_service_control_nrestarts_uses_posix_spawn_not_fork():
     import shutil
 
@@ -89,6 +90,7 @@ def test_service_control_nrestarts_uses_posix_spawn_not_fork():
     assert spy.hits.get("posix_spawn", 0) >= 1
 
 
+@pytest.mark.live_spawn  # 'wireplumber --version' — reads, changes nothing
 def test_pw_quirks_wireplumber_version_uses_posix_spawn_not_fork():
     import shutil
 


### PR DESCRIPTION
Part of #156 — first of three, and the only one that is a bug fix in released code. It does not depend on the other two.

## What happens today

Observed live on an Arctis Nova 7:

```
alsa_output.…Arctis_Nova_7….iec958-stereo:monitor_FL/FR  →  effect_input.sonar-micro-eq
```

The headset's **output monitor** was linked into the microphone EQ. Everything audible on the machine was being transmitted as the microphone — a video playing in a browser went out over a Discord call as though the user were speaking it. It reappeared on every daemon restart, so it came back with each package update.

## Root cause

One line in `core.py`:

```python
physical_in = physical_in or fallback   # fallback is the OUTPUT sink name
```

A Nova 7 on an `iec958-stereo` profile exposes no capture node of its own, so the microphone slot was filled with the sink name, and `ensure_micro_capture_link()` then wired that sink's monitor into the mic EQ.

## The fix, on both sides

- **`core.py`** — the input no longer shares the output's fallback. Empty is the honest answer; the watchdog links a real source once one appears.
- **`pw_utils.ensure_capture_link()`** — refuses a source whose `media.class` is `Audio/Sink` outright.

The second half is deliberately belt-and-braces rather than left to call sites. This is the one mistake on the input side that is completely inaudible to the person making it: nothing locally indicates that the desktop is being transmitted, so it should not depend on every caller getting the source right.

## Test isolation, carried in this PR

`tests/conftest.py` now refuses to run `pactl`/`pw-*`/`systemctl` against the developer's own sound server, with `tests/test_sonar_to_pipewire.py` and `tests/test_spawn_no_fork.py` fixing the three tests that were escaping through it.

This is not hypothetical: running the suite without the guard restarted wireplumber and disturbed a live Discord call on the machine this was developed on. The same three files appear in the other two PRs so each branch can be run standalone — the content is identical and merges cleanly.

## Testing

`1 199 passed, 3 skipped`. The new `tests/test_mic_never_fed_by_an_output.py` covers both halves: the fallback no longer leaks the output name, and a sink offered as a capture source is refused.
