### PR TITLE
fix(pw-dump): recover graph state from concatenated JSON documents (random audio dropouts)

### DIFF
--- a/src/arctis_sound_manager/pw_utils.py
+++ b/src/arctis_sound_manager/pw_utils.py
@@ -248,10 +248,69 @@ def reapply_routing_overrides(timeout_s: float = 6.0) -> int:
     return moved
 
 
+def _parse_pw_dump_output(text: str) -> list | None:
+    """Recover a usable dump from ``pw-dump`` output that failed a plain
+    ``json.loads`` (issue: random ASM audio dropouts, diagnosed on PipeWire
+    1.0.5, Aug 2026).
+
+    A single non-monitor ``pw-dump`` invocation is documented as printing one
+    JSON array, but in practice it can print **more than one**, concatenated
+    back-to-back with no separator, when a registry object is added/removed
+    while pw-dump is still enumerating the graph. The extra document observed
+    here is a tiny one-element "tombstone" array like ``[{"id": N, "info":
+    null}]`` — and it can appear *before or after* the real dump, so the
+    real dump is not reliably "the first document".
+
+    ``json.loads`` treats any trailing bytes after the first valid document
+    as a hard parse error ("Extra data"), so ``_pw_dump()`` used to return
+    ``[]`` on every one of these — an apparently *empty* PipeWire graph. The
+    loopback watchdog (``core.py: _loopback_watchdog``) reads an empty dump
+    as "every loopback/EQ target is gone" and escalates to recreating
+    loopbacks and restarting the filter-chain service — tearing down and
+    rebuilding the exact audio path that was actually fine. That churn is
+    the mechanism behind ASM's random audio dropouts, not any real failure
+    of PipeWire or the headset.
+
+    This walks every concatenated JSON document in the output via
+    ``JSONDecoder.raw_decode`` and returns the largest list (by object
+    count) — the real dump always has hundreds of entries; a tombstone has
+    exactly one. Returns ``None`` if nothing parseable was found at all.
+    """
+    decoder = json.JSONDecoder()
+    idx = 0
+    n = len(text)
+    best: list | None = None
+    while idx < n:
+        while idx < n and text[idx] in " \t\r\n":
+            idx += 1
+        if idx >= n:
+            break
+        try:
+            obj, end = decoder.raw_decode(text, idx)
+        except Exception:
+            break
+        if isinstance(obj, list) and (best is None or len(obj) > len(best)):
+            best = obj
+        idx = end
+    return best
+
+
 def _pw_dump() -> list:
     try:
         r = _pw_run(["pw-dump"], capture_output=True, text=True, timeout=3)
-        return json.loads(r.stdout)
+        try:
+            return json.loads(r.stdout)
+        except json.JSONDecodeError:
+            recovered = _parse_pw_dump_output(r.stdout)
+            if recovered is not None:
+                logger.info(
+                    "pw-dump: output had concatenated JSON documents "
+                    "(%d bytes) — recovered the real dump (%d objects) "
+                    "instead of treating the graph as empty",
+                    len(r.stdout), len(recovered),
+                )
+                return recovered
+            raise
     except Exception as e:
         logger.warning("pw-dump failed: %s", e)
         return []

--- a/src/arctis_sound_manager/scripts/stream_guard.py
+++ b/src/arctis_sound_manager/scripts/stream_guard.py
@@ -30,7 +30,7 @@ import time
 from pathlib import Path
 
 from arctis_sound_manager.log_setup import configure_logging
-from arctis_sound_manager.pw_utils import _abs_exe, _pw_run
+from arctis_sound_manager.pw_utils import _abs_exe, _pw_run, _parse_pw_dump_output
 from arctis_sound_manager.stream_guard import (CONFIG_FILE,
                                                DEFAULT_CAPTURE_NODES,
                                                GuardConfig, describe_cut,
@@ -79,10 +79,24 @@ def _current_config() -> GuardConfig:
 # ── PipeWire I/O ───────────────────────────────────────────────────────────
 
 def _pw_dump() -> list:
-    """Snapshot the graph. Returns [] on failure — the tick then does nothing."""
+    """Snapshot the graph. Returns [] on failure — the tick then does nothing.
+
+    ``pw-dump`` can print more than one concatenated JSON document when a
+    registry object is added/removed mid-enumeration (see
+    ``pw_utils._parse_pw_dump_output`` for the full explanation). Falls back
+    to that recovery path instead of treating a momentary hiccup as an empty
+    graph, which used to make Stream Guard miss a tick of screen-share
+    policing.
+    """
     try:
         r = _pw_run(["pw-dump"], capture_output=True, text=True, timeout=3)
-        return json.loads(r.stdout)
+        try:
+            return json.loads(r.stdout)
+        except json.JSONDecodeError:
+            recovered = _parse_pw_dump_output(r.stdout)
+            if recovered is not None:
+                return recovered
+            raise
     except Exception as exc:
         log.warning("pw-dump failed: %s", exc)
         return []

--- a/tests/test_pw_utils.py
+++ b/tests/test_pw_utils.py
@@ -3,7 +3,10 @@
 
 """Tests for pw_utils — native PipeWire stream detection and routing."""
 
+import json
+
 from arctis_sound_manager.pw_utils import (
+    _parse_pw_dump_output,
     get_native_streams,
     loopback_link_target,
     move_native_stream,
@@ -489,3 +492,72 @@ class TestSetFilterGain:
         ok = pw_utils.set_filter_gain("effect_input.sonar-output-eq", "boost:Gain", 1.0)
 
         assert ok is False
+
+
+class TestParsePwDumpOutput:
+    """pw-dump can occasionally print more than one JSON document,
+    concatenated with no separator, when a registry object is
+    added/removed mid-enumeration. ``_parse_pw_dump_output`` recovers the
+    real dump instead of ``_pw_dump()`` treating the graph as empty (which
+    used to make the loopback watchdog tear down healthy loopbacks and
+    restart the filter-chain for no reason — the mechanism behind ASM's
+    random audio dropouts).
+    """
+
+    def test_single_valid_document_returns_it(self):
+        text = '[{"id": 1, "info": null}, {"id": 2, "info": null}]'
+        result = _parse_pw_dump_output(text)
+        assert result == [{"id": 1, "info": None}, {"id": 2, "info": None}]
+
+    def test_tombstone_after_real_dump_is_ignored(self):
+        real = [{"id": i, "info": None} for i in range(50)]
+        text = json.dumps(real) + "\n" + json.dumps([{"id": 152, "info": None}]) + "\n"
+        result = _parse_pw_dump_output(text)
+        assert result == real
+
+    def test_tombstone_before_real_dump_is_ignored(self):
+        real = [{"id": i, "info": None} for i in range(50)]
+        text = json.dumps([{"id": 152, "info": None}]) + "\n" + json.dumps(real) + "\n"
+        result = _parse_pw_dump_output(text)
+        assert result == real
+
+    def test_multiple_tombstones_still_picks_largest(self):
+        real = [{"id": i, "info": None} for i in range(50)]
+        text = (
+            json.dumps([{"id": 1, "info": None}]) + "\n"
+            + json.dumps(real) + "\n"
+            + json.dumps([{"id": 2, "info": None}]) + "\n"
+        )
+        result = _parse_pw_dump_output(text)
+        assert result == real
+
+    def test_no_valid_json_returns_none(self):
+        assert _parse_pw_dump_output("not json at all") is None
+
+    def test_empty_string_returns_none(self):
+        assert _parse_pw_dump_output("") is None
+
+    def test_pw_dump_recovers_from_concatenated_output(self, monkeypatch):
+        """End-to-end: _pw_dump() itself falls back to the recovery path
+        instead of returning [] on a JSONDecodeError."""
+        real = [{"id": i, "info": None} for i in range(50)]
+        stdout = json.dumps(real) + "\n" + json.dumps([{"id": 152, "info": None}]) + "\n"
+
+        def fake_run(argv, **kwargs):
+            return types.SimpleNamespace(returncode=0, stdout=stdout, stderr="")
+
+        monkeypatch.setattr(pw_utils, "_pw_run", fake_run)
+
+        result = pw_utils._pw_dump()
+
+        assert result == real
+
+    def test_pw_dump_still_returns_empty_on_genuine_garbage(self, monkeypatch):
+        def fake_run(argv, **kwargs):
+            return types.SimpleNamespace(returncode=0, stdout="not json", stderr="")
+
+        monkeypatch.setattr(pw_utils, "_pw_run", fake_run)
+
+        result = pw_utils._pw_dump()
+
+        assert result == []

--- a/uv.lock
+++ b/uv.lock
@@ -4,7 +4,7 @@ requires-python = ">=3.10"
 
 [[package]]
 name = "arctis-sound-manager"
-version = "1.2.5"
+version = "1.2.20"
 source = { editable = "." }
 dependencies = [
     { name = "babel" },


### PR DESCRIPTION
## Summary
ASM's random audio dropouts on a live Arctis Nova Pro Wireless setup (v1.2.20, Ubuntu 24.04/Mint 22.3, PipeWire 1.0.5) trace back to `pw_utils._pw_dump()` treating a **momentary, cosmetic `pw-dump` output glitch as "the entire PipeWire graph vanished"**, which makes `_loopback_watchdog` tear down and recreate perfectly healthy loopbacks/filter-chain links.

## Root cause
`pw-dump` (non-monitor, single-shot invocation) is documented as printing one JSON array, but in practice — confirmed by running it in a tight loop against a live graph — it occasionally prints **a second, tiny JSON document concatenated with no separator** when a registry object is added/removed while pw-dump is still enumerating (observed ~1 time in 10-20 invocations under normal desktop use):

```
[
  { ...277 real graph objects... }
]
[
  {"id": 152, "info": null}
]
```

The tombstone doc can land **before or after** the real dump.

`_pw_dump()`:
```python
def _pw_dump() -> list:
    try:
        r = _pw_run(["pw-dump"], capture_output=True, text=True, timeout=3)
        return json.loads(r.stdout)
    except Exception as e:
        logger.warning("pw-dump failed: %s", e)
        return []
```

`json.loads` throws `JSONDecodeError: Extra data` on the trailing bytes, so this returns `[]` — an apparently **empty graph**. Every caller of `_pw_dump()` (the loopback watchdog's link-enforcement passes, `pw_node_exists`, etc.) then concludes every loopback/EQ target is gone and escalates:

```
_loopback_watchdog: loopback 'game' unlinkable for 3 ticks (target present) — recreating
_loopback_watchdog: loopback 'game' flapping (3 recreations/60s) — backing off for 60s
_loopback_watchdog: target '...' absent for N ticks — regenerated missing EQ config(s), restarting filter-chain
```

This churn — destroying/recreating `pw-loopback` processes and restarting the filter-chain service — is what's audible as a "random" audio dropout. It's not a real PipeWire/USB/headset fault; the graph was fine the whole time.

Confirmed live: on this machine, `pw-dump failed: Extra data: ...` fired roughly every 15-25 minutes over several hours of normal use, each time followed within the same second by loopback recreation / flapping-backoff / filter-chain-restart log lines.

## Fix
Instead of hard-failing on `json.loads`, walk every concatenated JSON document in the output (`JSONDecoder.raw_decode` in a loop) and keep the largest list — the real dump always has hundreds of objects, a tombstone has exactly one:

```python
def _parse_pw_dump_output(text: str) -> list | None:
    decoder = json.JSONDecoder()
    idx, n, best = 0, len(text), None
    while idx < n:
        while idx < n and text[idx] in " \t\r\n":
            idx += 1
        if idx >= n:
            break
        try:
            obj, end = decoder.raw_decode(text, idx)
        except Exception:
            break
        if isinstance(obj, list) and (best is None or len(obj) > len(best)):
            best = obj
        idx = end
    return best


def _pw_dump() -> list:
    try:
        r = _pw_run(["pw-dump"], capture_output=True, text=True, timeout=3)
        try:
            return json.loads(r.stdout)
        except json.JSONDecodeError:
            recovered = _parse_pw_dump_output(r.stdout)
            if recovered is not None:
                logger.info(
                    "pw-dump: output had concatenated JSON documents "
                    "(%d bytes) — recovered the real dump (%d objects) "
                    "instead of treating the graph as empty",
                    len(r.stdout), len(recovered),
                )
                return recovered
            raise
    except Exception as e:
        logger.warning("pw-dump failed: %s", e)
        return []
```

`scripts/stream_guard.py` has its own duplicate `_pw_dump()` with the identical bug (same "Extra data" → `[]` → guard misses a tick) — patched to import and reuse `pw_utils._parse_pw_dump_output` instead of duplicating the fragile logic.

Applied both patches locally and watched `arctis-manager` + `arctis-stream-guard` for the following window:
- Before: `pw-dump failed: Extra data` + loopback-churn log lines recurring every 15-25 min.
- After (same machine, same session, ~10+ min observed so far): the same "Extra data" condition still occurs at the same rate (confirmed via the new `pw-dump: output had concatenated JSON documents ... recovered the real dump (280 objects)` info line firing repeatedly), but **zero** `unlinkable`/`recreating`/`flapping`/`restarting filter-chain` events since — loopbacks stay linked straight through the glitch.

## Environment
- ASM 1.2.20 (apt/deb, Ubuntu/Mint)
- PipeWire 1.0.5, WirePlumber (bundled with Mint 22.3/Ubuntu 24.04 base)
- Device: Arctis Nova Pro Wireless
- Python 3.12 (system)

## Patch
Diffs attached below for `pw_utils.py` and `scripts/stream_guard.py`. Happy to open a PR against `develop` if that's preferred over a maintainer applying this directly.
