### PR TITLE
fix(routing): resolve app overrides through the per-channel output device (Channels tab output picker never sticks)

### DIFF
--- a/src/arctis_sound_manager/scripts/video_router.py
+++ b/src/arctis_sound_manager/scripts/video_router.py
@@ -238,6 +238,44 @@ def _lookup_override(overrides: dict, key: str, app: str) -> str | None:
     return None
 
 
+# Arctis virtual channel -> the key used in channel_output_devices.json
+# (the Channels tab's per-channel "output device" picker). Kept in one place
+# so _resolve_channel_output and the enforcement pass below can't drift.
+_CHANNEL_VIRTUAL_TO_KEY = {"Arctis_Game": "game", "Arctis_Chat": "chat", "Arctis_Media": "media"}
+
+
+def _resolve_channel_output(sink_name: str, channel_outputs: dict, sink_map: dict) -> str:
+    """Resolve *sink_name* through the user's per-channel output-device pick.
+
+    ``channel_output_devices.json`` (Channels tab -> per-channel "output
+    device" combo) redirects a whole Arctis virtual channel to an external
+    physical sink (e.g. Media -> onboard speakers). Every other place that
+    decides where a stream should go — most importantly per-app overrides in
+    ``routing_overrides.json`` — used to resolve straight to the bare virtual
+    sink name (``"Arctis_Media"``), ignoring that redirect entirely. Both
+    the app-override enforcement pass and the separate per-channel
+    enforcement pass then fought over the same stream every tick: the
+    override pass moved it back to ``Arctis_Media``, the channel-output pass
+    immediately moved it back out to the physical sink, forever — the user's
+    channel output device pick could never actually stick for any app that
+    also had (or acquired) a saved override.
+
+    Called wherever a target sink name is about to be compared/moved to, so
+    every enforcement path agrees on the same effective destination. Returns
+    *sink_name* unchanged when it isn't an Arctis virtual channel, the
+    channel has no configured external output, or that output isn't
+    currently present in the graph (falls back to the virtual channel rather
+    than silently going nowhere).
+    """
+    channel = _CHANNEL_VIRTUAL_TO_KEY.get(sink_name)
+    if channel is None:
+        return sink_name
+    target_name = channel_outputs.get(channel)
+    if not target_name or target_name not in sink_map:
+        return sink_name
+    return target_name
+
+
 def load_overrides() -> dict:
     if OVERRIDES_FILE.exists():
         try:
@@ -384,6 +422,7 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         return
 
     overrides = load_overrides()
+    channel_outputs = _load_channel_outputs()
     sink_inputs = pulse.sink_input_list()
     sink_map = {s.name: s.index for s in sinks}
     sink_idx_to_name = {s.index: s.name for s in sinks}
@@ -455,6 +494,11 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
                 wanted = auto
 
         if wanted is not None:
+            # Route through the user's per-channel output-device pick (Media
+            # -> onboard speakers, etc.) so this pass and the per-channel
+            # enforcement pass below agree on the same destination instead of
+            # fighting over it every tick (see _resolve_channel_output).
+            wanted = _resolve_channel_output(wanted, channel_outputs, sink_map)
             wanted_index = sink_map.get(wanted)
             if wanted_index is not None and si.sink != wanted_index:
                 log.info("Override: moving '%s' -> %s", app, wanted)
@@ -535,6 +579,8 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
                 wanted = auto
 
         if wanted is not None:
+            # Same channel-output redirect as the PA-stream pass above.
+            wanted = _resolve_channel_output(wanted, channel_outputs, sink_map)
             if s["sink_name"] is None or s["sink_name"] != wanted:
                 log.info("Override native: moving '%s' -> %s", app, wanted)
                 move_native_stream(s["id"], wanted)

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -25,6 +25,7 @@ from arctis_sound_manager.scripts.video_router import (
     _pa_placed,
     _native_placed,
     _process_tick,
+    _resolve_channel_output,
 )
 
 
@@ -531,3 +532,75 @@ def test_get_headset_power_unreachable_daemon_is_unknown():
         result = video_router.get_headset_power(force=True)
 
     assert result == HeadsetPower.UNKNOWN
+
+
+# ── _resolve_channel_output / channel-output-device tug-of-war ───────────────
+#
+# channel_output_devices.json (Channels tab -> per-channel "output device"
+# combo) redirects a whole Arctis virtual channel to an external physical
+# sink. Before this fix, only the dedicated "Channel output" enforcement
+# pass at the end of _process_tick knew about that redirect — the earlier
+# per-app override enforcement pass resolved straight to the bare virtual
+# sink name. For any app that ALSO had a saved routing override pointing at
+# that channel (e.g. "Brave": "Arctis_Media"), the two passes fought every
+# tick: the channel-output pass moved the stream out to the physical sink,
+# then the very next tick the override pass moved it straight back to
+# Arctis_Media, forever — the channel-output setting could never actually
+# stick for that app.
+
+def test_resolve_channel_output_redirects_configured_channel():
+    speakers = _FakeSink(5, "alsa_output.usb-Generic_USB_Audio-00.HiFi__hw_Audio__sink")
+    sink_map = {"Arctis_Media": 1, speakers.name: speakers.index}
+    channel_outputs = {"media": speakers.name}
+
+    assert _resolve_channel_output("Arctis_Media", channel_outputs, sink_map) == speakers.name
+
+
+def test_resolve_channel_output_passthrough_when_not_configured():
+    sink_map = {"Arctis_Media": 1}
+    assert _resolve_channel_output("Arctis_Media", {}, sink_map) == "Arctis_Media"
+
+
+def test_resolve_channel_output_passthrough_for_non_virtual_sink():
+    sink_map = {"Arctis_Media": 1, "alsa_output.hdmi-stereo": 0}
+    channel_outputs = {"media": "alsa_output.hdmi-stereo"}
+    # Not one of the three Arctis virtual channels — never redirected.
+    assert _resolve_channel_output("alsa_output.hdmi-stereo", channel_outputs, sink_map) == \
+        "alsa_output.hdmi-stereo"
+
+
+def test_resolve_channel_output_falls_back_when_target_sink_absent():
+    """The configured external output isn't in the current graph (unplugged,
+    not yet enumerated) — fall back to the virtual channel rather than
+    resolving to a sink that doesn't exist."""
+    sink_map = {"Arctis_Media": 1}
+    channel_outputs = {"media": "alsa_output.usb-Generic_USB_Audio-00.HiFi__hw_Audio__sink"}
+    assert _resolve_channel_output("Arctis_Media", channel_outputs, sink_map) == "Arctis_Media"
+
+
+def test_tick_override_and_channel_output_agree_no_oscillation():
+    """The regression this fix targets: an app with BOTH a saved override
+    pointing at 'Arctis_Media' AND a channel_output_devices.json redirect of
+    'media' to a physical sink must land on the physical sink in a single
+    tick — and a second tick must be a no-op (no further moves), never an
+    infinite back-and-forth."""
+    media = _FakeSink(1, "Arctis_Media")
+    speakers = _FakeSink(2, "alsa_output.usb-Generic_USB_Audio-00.HiFi__hw_Audio__sink")
+    si = _FakeSinkInput(10, sink=media.index, proplist={"application.name": "Brave"})
+    pulse = _FakePulse([media, speakers], [si], default_sink_name=media.name)
+
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={"Brave": "Arctis_Media"}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides"), \
+         patch("arctis_sound_manager.scripts.video_router._load_channel_outputs",
+               return_value={"media": speakers.name}):
+        _process_tick(pulse)
+        assert pulse.moves == [(si.index, speakers.index)]
+        assert si.sink == speakers.index
+
+        # Second tick: already on the resolved target — must be a no-op.
+        _process_tick(pulse)
+        assert pulse.moves == [(si.index, speakers.index)]
+        assert si.sink == speakers.index


### PR DESCRIPTION
## Summary
`routing_overrides.json` (per-app pins, e.g. `"Brave": "Arctis_Media"`) and `channel_output_devices.json` (the Channels tab's per-channel "output device" combo, e.g. Media -> onboard speakers) are two independent settings that both decide where a stream should end up — but only the dedicated "Channel output" enforcement pass at the end of `_process_tick` knew about the `channel_output_devices.json` redirect. The earlier per-app override enforcement pass resolved straight to the bare virtual sink name (`"Arctis_Media"`), ignoring it entirely.

## Symptom
User-reported: "I can't change audio device — sometimes I don't want to use my headphones, instead I want to use the speakers on the audio-out jack." Setting Media's output device to onboard speakers in the Channels tab appeared to have no effect for at least one app (Brave), even though the setting was saved correctly and `pactl move-sink-input` to that exact sink worked and held.

## Root cause
For any app that had **both** a saved override pointing at a channel (`"Brave": "Arctis_Media"`) **and** that channel had a configured external output (`{"media": "alsa_output...HiFi__hw_Audio__sink"}`), the two enforcement passes fought every tick:

```
Aug 11 01:21:37 asm-router[...]: [INFO] Override: moving 'Brave' -> Arctis_Media
Aug 11 01:21:43 asm-router[...]: [INFO] Channel output: 'Brave' Arctis_Media -> alsa_output...HiFi__hw_Audio__sink
Aug 11 01:21:43 asm-router[...]: [INFO] Override: moving 'Brave' -> Arctis_Media
Aug 11 01:21:50 asm-router[...]: [INFO] Channel output: 'Brave' Arctis_Media -> alsa_output...HiFi__hw_Audio__sink
Aug 11 01:21:50 asm-router[...]: [INFO] Override: moving 'Brave' -> Arctis_Media
... (repeats every ~6s, forever)
```

The channel-output pass moves the stream to the physical sink; the very next tick the override-enforcement pass (which only knows about `Arctis_Media`, the bare virtual sink name) moves it straight back. The Channels tab's output-device picker can never actually stick for any app that also has a saved routing override on that channel.

Confirmed reproducible on a live system (Nova Pro Wireless, PipeWire 1.0.5): `journalctl --user -u arctis-video-router -f` shows the two log lines alternating indefinitely, ~every 6 seconds, for as long as both settings coexist.

## Fix
`_resolve_channel_output(sink_name, channel_outputs, sink_map)`: given a resolved override target, checks whether it names one of the three Arctis virtual channels (`Arctis_Game`/`Arctis_Chat`/`Arctis_Media`) that has a configured external output in `channel_output_devices.json`, and if so redirects to that output — falling back to the virtual channel unchanged when the configured target isn't currently present in the graph (unplugged / not yet enumerated), rather than resolving to a sink that doesn't exist.

Wired into both the PulseAudio-stream and native-PipeWire-stream (`get_native_streams`) override-enforcement loops, immediately before each compares/moves against `wanted`. Both loops and the dedicated per-channel enforcement pass now agree on the same effective destination instead of treating it as two independently-contested sources of truth.

## Tests
`tests/test_video_router.py`:
- `test_resolve_channel_output_redirects_configured_channel` / `_passthrough_when_not_configured` / `_passthrough_for_non_virtual_sink` / `_falls_back_when_target_sink_absent` — unit coverage of the new resolver.
- `test_tick_override_and_channel_output_agree_no_oscillation` — integration test through `_process_tick` reproducing the exact regression: an app with both a saved override and a channel-output redirect lands on the physical sink in one tick, and a second tick is a no-op (no further moves) instead of oscillating.

Full suite: `1352 passed, 3 skipped` (5 pre-existing unrelated failures in `test_sonar_to_pipewire.py` reproduce identically on a clean `develop` checkout with no changes applied — confirmed before opening this PR, not caused by this change).

## Environment
- ASM (develop branch, current HEAD as of this PR)
- PipeWire 1.0.5
- Device: Arctis Nova Pro Wireless
- Reproduced with Media channel's output device set to a physical USB/onboard audio sink and `"Brave": "Arctis_Media"` in `routing_overrides.json`
