### PR TITLE
fix(router): never steal streams pinned to foreign virtual sinks

### DIFF
--- a/src/arctis_sound_manager/scripts/video_router.py
+++ b/src/arctis_sound_manager/scripts/video_router.py
@@ -309,6 +309,33 @@ def _is_physical_arctis(sink_name: str) -> bool:
     return "SteelSeries_Arctis" in sink_name and not sink_name.startswith("Arctis_")
 
 
+def _explicit_pin_target(props: dict, sink_map: dict) -> str | None:
+    """Return the foreign virtual sink a stream is explicitly pinned to, or None.
+
+    A stream that sets ``target.object`` / ``node.target`` to a *virtual*
+    sink that is not one of ASM's own nodes is part of another app's routing
+    graph — e.g. a soundboard feeding its mic-injection stream into a
+    virtual-microphone sink (SoundDeck). Adopting or overriding such a
+    stream doesn't just change where it is heard, it breaks the other app's
+    feature entirely, so the router must leave it alone (and put it back if
+    it was moved before this guard existed).
+
+    Deliberately narrow: pins to hardware outputs (``alsa_output.*`` /
+    ``bluez_output.*``) are NOT exempt — pulling audible streams from other
+    physical outputs onto the headset is the router's advertised adoption
+    behavior (issue #20). Pins to ASM's own sinks follow normal routing.
+    A target that names no currently-present sink is ignored.
+    """
+    target = props.get("target.object") or props.get("node.target") or ""
+    if not isinstance(target, str) or target not in sink_map:
+        return None
+    if target.startswith(("Arctis_", "effect_input.", "alsa_output.", "bluez_output.")):
+        return None
+    if _is_physical_arctis(target):
+        return None
+    return target
+
+
 def _subscribe(pulse: pulsectl.Pulse) -> None:
     """Subscribe to sink and sink-input events; stop the loop on any event."""
     pulse.event_mask_set('sink', 'sink_input')
@@ -406,9 +433,14 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         )
         if default_sink and not default_is_arctis:
             idx_to_name = {s.index: s.name for s in sinks}
+            name_to_idx = {s.name: s.index for s in sinks}
             for si in pulse.sink_input_list():
                 app = si.proplist.get("application.name", "")
                 if not app:
+                    continue
+                if _explicit_pin_target(si.proplist, name_to_idx) is not None:
+                    # Pinned to a foreign virtual sink (e.g. a virtual-mic
+                    # feed) — unaffected by the headset being off.
                     continue
                 on_arctis = any(
                     k in idx_to_name.get(si.sink, "") for k in ARCTIS_VIRTUAL_SINKS
@@ -437,6 +469,18 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         # Composite key (issue #108): disambiguates apps that share a
         # generic application.name such as "Chromium".
         key = app_override_key(app, si.proplist.get("application.process.binary", ""))
+
+        # A stream explicitly pinned to a foreign virtual sink is off-limits
+        # to every pass below — restore it if something already moved it.
+        # Skipped before any _pa_placed bookkeeping so a same-named sibling
+        # stream (e.g. SoundDeck's monitor stream) keeps its own tracking.
+        pinned = _explicit_pin_target(si.proplist, sink_map)
+        if pinned is not None:
+            pinned_index = sink_map[pinned]
+            if si.sink != pinned_index:
+                log.info("Pinned stream: '%s' back -> %s", app, pinned)
+                pulse.sink_input_move(si.index, pinned_index)
+            continue
 
         # Detect manual move: app was placed by router but is now elsewhere
         if key in _pa_placed and si.sink != _pa_placed[key]:
@@ -529,6 +573,14 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         binary = s.get("props", {}).get("application.process.binary", "")
         key = app_override_key(app, binary)
 
+        # Same foreign-virtual-sink pin guard as the PA pass above.
+        pinned = _explicit_pin_target(s.get("props", {}), sink_map)
+        if pinned is not None:
+            if s["sink_name"] != pinned:
+                log.info("Pinned native stream: '%s' back -> %s", app, pinned)
+                move_native_stream(s["id"], pinned)
+            continue
+
         # Detect manual move for native streams
         if key in _native_placed:
             placed = _native_placed[key]
@@ -605,6 +657,8 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
             for _si in sink_inputs:
                 _app = _si.proplist.get("application.name", "")
                 if not _app:
+                    continue
+                if _explicit_pin_target(_si.proplist, sink_map) is not None:
                     continue
                 _key = app_override_key(_app, _si.proplist.get("application.process.binary", ""))
                 _current_name = sink_idx_to_name.get(_si.sink, "")

--- a/src/arctis_sound_manager/scripts/video_router.py
+++ b/src/arctis_sound_manager/scripts/video_router.py
@@ -325,6 +325,13 @@ def _explicit_pin_target(props: dict, sink_map: dict) -> str | None:
     physical outputs onto the headset is the router's advertised adoption
     behavior (issue #20). Pins to ASM's own sinks follow normal routing.
     A target that names no currently-present sink is ignored.
+
+    Not exhaustive: ``target.object`` also accepts an ``object.serial``, and
+    this only matches ``node.name``, so a stream pinned by serial is not
+    recognised and is adopted as before. Resolving those would mean mapping
+    PipeWire serials to nodes (the PulseAudio sink index is a different
+    number), which is more machinery than the case seen in the wild warrants.
+    Do not read this guard as covering every possible pin.
     """
     target = props.get("target.object") or props.get("node.target") or ""
     if not isinstance(target, str) or target not in sink_map:
@@ -477,7 +484,18 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         pinned = _explicit_pin_target(si.proplist, sink_map)
         if pinned is not None:
             pinned_index = sink_map[pinned]
-            if si.sink != pinned_index:
+            # Undo only *our* displacement. Sitting on an ASM sink is the
+            # evidence that the router put it there (before this guard
+            # existed); anywhere else and the user moved it themselves from a
+            # mixer, which is not ours to drag back. Without this test the
+            # router would hold these streams tighter than any other, undoing
+            # a deliberate manual move within a tick and offering no way out.
+            current_name = sink_idx_to_name.get(si.sink, "")
+            displaced_by_us = (
+                any(k in current_name for k in ARCTIS_VIRTUAL_SINKS)
+                or current_name.startswith("effect_input.")
+            )
+            if si.sink != pinned_index and displaced_by_us:
                 log.info("Pinned stream: '%s' back -> %s", app, pinned)
                 pulse.sink_input_move(si.index, pinned_index)
             continue
@@ -573,10 +591,16 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
         binary = s.get("props", {}).get("application.process.binary", "")
         key = app_override_key(app, binary)
 
-        # Same foreign-virtual-sink pin guard as the PA pass above.
+        # Same foreign-virtual-sink pin guard as the PA pass above, including
+        # the "only undo our own displacement" rule.
         pinned = _explicit_pin_target(s.get("props", {}), sink_map)
         if pinned is not None:
-            if s["sink_name"] != pinned:
+            current_name = s["sink_name"] or ""
+            displaced_by_us = (
+                any(k in current_name for k in ARCTIS_VIRTUAL_SINKS)
+                or current_name.startswith("effect_input.")
+            )
+            if current_name != pinned and displaced_by_us:
                 log.info("Pinned native stream: '%s' back -> %s", app, pinned)
                 move_native_stream(s["id"], pinned)
             continue

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -604,3 +604,118 @@ def test_tick_override_and_channel_output_agree_no_oscillation():
         _process_tick(pulse)
         assert pulse.moves == [(si.index, speakers.index)]
         assert si.sink == speakers.index
+
+
+# ── Foreign-virtual-sink pins (SoundDeck-style virtual-mic feeds) ─────────────
+# A stream that explicitly targets a virtual sink belonging to another app
+# (target.object → e.g. a soundboard's virtual-microphone sink) is part of
+# that app's routing graph. Adopting or overriding it breaks the feature
+# (the mic feed gets played out loud instead of injected into the virtual
+# mic), so the router must leave such streams alone — and restore them.
+
+from arctis_sound_manager.scripts.video_router import _explicit_pin_target
+
+
+def test_explicit_pin_target_foreign_virtual_sink():
+    sink_map = {"SoundDeck": 5, "Arctis_Media": 1}
+    props = {"target.object": "SoundDeck"}
+    assert _explicit_pin_target(props, sink_map) == "SoundDeck"
+
+
+def test_explicit_pin_target_ignores_asm_and_hardware_sinks():
+    sink_map = {"Arctis_Media": 1, "effect_input.sonar-game-eq": 2,
+                "alsa_output.hdmi-stereo": 3, "bluez_output.aa_bb.1": 4,
+                "alsa_output.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00.analog-stereo": 6}
+    for target in sink_map:
+        assert _explicit_pin_target({"target.object": target}, sink_map) is None
+
+
+def test_explicit_pin_target_absent_or_unknown_target():
+    sink_map = {"SoundDeck": 5}
+    assert _explicit_pin_target({}, sink_map) is None
+    assert _explicit_pin_target({"target.object": "GoneSink"}, sink_map) is None
+
+
+def test_tick_pinned_stream_not_adopted_and_restored():
+    """A stream pinned to a foreign virtual sink must never be adopted onto
+    Arctis_Media (no override written), and if it was already dragged onto
+    an Arctis sink it must be moved back to its pinned target."""
+    game = _FakeSink(0, "Arctis_Game")
+    media = _FakeSink(1, "Arctis_Media")
+    sounddeck = _FakeSink(2, "SoundDeck")
+    # Stolen earlier: currently sits on Arctis_Media despite its pin.
+    si = _FakeSinkInput(10, sink=media.index, proplist={
+        "application.name": "SoundDeck",
+        "target.object": "SoundDeck",
+    })
+    pulse = _FakePulse([game, media, sounddeck], [si], default_sink_name=game.name)
+
+    saved = MagicMock()
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides", saved):
+        _process_tick(pulse)
+
+    assert si.sink == sounddeck.index
+    saved.assert_not_called()
+
+    # Second tick: already home — no further moves.
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides", saved):
+        _process_tick(pulse)
+    assert pulse.moves == [(si.index, sounddeck.index)]
+
+
+def test_tick_pinned_stream_ignores_app_override_while_sibling_follows_it():
+    """Two streams from the same app (soundboard monitor + mic feed): the
+    unpinned monitor stream follows the app's saved override to Arctis_Media,
+    the pinned mic-feed stream stays on the foreign virtual sink."""
+    game = _FakeSink(0, "Arctis_Game")
+    media = _FakeSink(1, "Arctis_Media")
+    sounddeck = _FakeSink(2, "SoundDeck")
+    monitor = _FakeSinkInput(10, sink=game.index, proplist={
+        "application.name": "SoundDeck",
+    })
+    mic_feed = _FakeSinkInput(11, sink=sounddeck.index, proplist={
+        "application.name": "SoundDeck",
+        "target.object": "SoundDeck",
+    })
+    pulse = _FakePulse([game, media, sounddeck], [monitor, mic_feed],
+                       default_sink_name=game.name)
+
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={"SoundDeck": "Arctis_Media"}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides"):
+        _process_tick(pulse)
+
+    assert monitor.sink == media.index
+    assert mic_feed.sink == sounddeck.index
+    assert pulse.moves == [(monitor.index, media.index)]
+
+
+def test_tick_offline_pinned_stream_not_repatriated():
+    """Headset off: a pinned virtual-mic feed is unaffected (the virtual mic
+    works without the headset) — it must not be pulled to the default sink."""
+    hdmi = _FakeSink(0, "alsa_output.hdmi-stereo")
+    media = _FakeSink(1, "Arctis_Media")
+    sounddeck = _FakeSink(2, "SoundDeck")
+    si = _FakeSinkInput(10, sink=sounddeck.index, proplist={
+        "application.name": "SoundDeck",
+        "target.object": "SoundDeck",
+    })
+    pulse = _FakePulse([hdmi, media, sounddeck], [si], default_sink_name=hdmi.name)
+
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.OFF), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides"):
+        _process_tick(pulse)
+
+    assert pulse.moves == []
+    assert si.sink == sounddeck.index

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -671,6 +671,36 @@ def test_tick_pinned_stream_not_adopted_and_restored():
     assert pulse.moves == [(si.index, sounddeck.index)]
 
 
+def test_tick_pinned_stream_moved_by_user_is_left_alone():
+    """Restoring a pinned stream must only undo *our* displacement.
+
+    Sitting on an ASM sink is the evidence the router put it there. A pinned
+    stream the user moved to some other output from a mixer is not ours to
+    drag back: doing so would hold these streams tighter than any other
+    stream in the graph, undoing a deliberate manual move every tick with no
+    way to override it.
+    """
+    game = _FakeSink(0, "Arctis_Game")
+    sounddeck = _FakeSink(2, "SoundDeck")
+    speakers = _FakeSink(3, "alsa_output.usb-Generic_Speakers-00.analog-stereo")
+    # Pinned to SoundDeck, but the user parked it on their speakers.
+    si = _FakeSinkInput(10, sink=speakers.index, proplist={
+        "application.name": "SoundDeck",
+        "target.object": "SoundDeck",
+    })
+    pulse = _FakePulse([game, sounddeck, speakers], [si], default_sink_name=game.name)
+
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides"):
+        _process_tick(pulse)
+
+    assert pulse.moves == [], "a user-placed pinned stream must not be moved"
+    assert si.sink == speakers.index
+
+
 def test_tick_pinned_stream_ignores_app_override_while_sibling_follows_it():
     """Two streams from the same app (soundboard monitor + mic feed): the
     unpinned monitor stream follows the app's saved override to Arctis_Media,


### PR DESCRIPTION
A stream that sets target.object/node.target to a virtual sink that is not one of ASM's own nodes (e.g. a soundboard feeding its mic-injection stream into a virtual-microphone sink like SoundDeck) is part of another app's routing graph. The adopt fallback (issue #20) and per-app overrides moved such streams onto Arctis_Media anyway — overrides are keyed by application.name, so a soundboard's monitor stream and its virtual-mic feed were dragged to the same output, silently breaking mic injection.

The router now leaves explicitly-pinned streams alone in every pass (manual-move detection, adoption/auto-route, override enforcement, per-channel output enforcement, headset-off repatriation) and moves them back to their pinned sink if they were displaced. Pins to ASM's own sinks and to hardware outputs (alsa_output.*/bluez_output.*) are deliberately not exempt, so adoption from other physical outputs keeps working as before.

Please do a review if this is the proper way to implement this and wont cause regressions / false positives for exclusions