### PR TITLE
perf(home): stop rebuilding the application lists twice a second

### DIFF
--- a/src/arctis_sound_manager/gui/home_page.py
+++ b/src/arctis_sound_manager/gui/home_page.py
@@ -1722,23 +1722,47 @@ class HomePage(QWidget):
         return name or "Audio"
 
     def _update_apps(self, sink_inputs, sinks: list, card: "AudioCard"):
+        """Redraw a card's application tags — but only when they changed.
+
+        This runs on the 500 ms poll, and it used to clear the row and build a
+        fresh widget per application every single time: two full teardowns and
+        rebuilds a second, for a list that changes when somebody opens a game.
+        The cost lands exactly where it is most visible — dragging an app to
+        another channel is a drag, a rebuild, and a repaint fighting each other
+        — which is what "moving applications between channels stutters" is.
+
+        The tags are rebuilt when the row they would produce differs from the
+        row that is already there, and left alone otherwise.
+        """
         if not sinks:
-            card.clear_apps()
+            if getattr(card, "_app_sig", None) != ():
+                card.clear_apps()
+                card._app_sig = ()
             return
         sink_indices = {s.index for s in sinks}
         matching = [
             si for si in sink_inputs
             if si.sink in sink_indices and "application.name" in si.proplist
         ]
-        card.clear_apps()
+
+        rows: list[tuple[str, int, int]] = []
         seen_names: set[str] = set()
         for si in matching:
             app_name = self._friendly_app_name(si.proplist)
             if app_name in seen_names:
                 continue
             seen_names.add(app_name)
-            pid = int(si.proplist.get("application.process.id", 0))
-            card.add_app_tag(app_name, si.index, pid, bg_color=card._accent)
+            rows.append((app_name, si.index,
+                         int(si.proplist.get("application.process.id", 0))))
+
+        signature = tuple(rows)
+        if getattr(card, "_app_sig", None) == signature:
+            return
+        card._app_sig = signature
+
+        card.clear_apps()
+        for app_name, si_index, pid in rows:
+            card.add_app_tag(app_name, si_index, pid, bg_color=card._accent)
 
     def _style_unassigned(self) -> None:
         """Header styling, kept flat and quiet: this is a list, not an alert."""
@@ -1832,6 +1856,7 @@ class HomePage(QWidget):
         # entirely rather than sitting there empty.
         if not rows and not hidden_count:
             self._unassigned_wrap.setVisible(False)
+            self._unassigned_sig = None
             return
         self._unassigned_wrap.setVisible(True)
 
@@ -1842,6 +1867,16 @@ class HomePage(QWidget):
             I18n.translate("ui", "unassigned_show_hidden").format(count=hidden_count))
         self._unassigned_show_hidden.setVisible(hidden_count > 0)
         self._unassigned_body.setVisible(self._unassigned_expanded and bool(rows))
+
+        # Same rule as the cards above: this is on the 500 ms poll, and each row
+        # is a composite widget with its own buttons. Rebuilding a list that has
+        # not changed, twice a second, is work the user feels as a stutter in
+        # whatever they are doing on top of it.
+        signature = tuple((r["key"], r["label"], r["where"], r["si_index"], r["pid"])
+                          for r in rows)
+        if signature == getattr(self, "_unassigned_sig", None):
+            return
+        self._unassigned_sig = signature
 
         while self._unassigned_area.count():
             item = self._unassigned_area.takeAt(0)

--- a/src/arctis_sound_manager/gui/home_page.py
+++ b/src/arctis_sound_manager/gui/home_page.py
@@ -258,6 +258,9 @@ class AudioCard(QWidget):
 
         self._apps_area = QVBoxLayout()
         self._apps_area.setSpacing(4)
+        # What the application row currently shows, so a poll that would draw
+        # the same thing can leave it alone. None means "nothing drawn yet".
+        self._app_sig: tuple | None = None
         apps_layout.addLayout(self._apps_area)
         apps_layout.addStretch(1)
 
@@ -389,6 +392,7 @@ class AudioCard(QWidget):
         self._apps_area.addWidget(tag)
 
     def clear_apps(self):
+        self._app_sig = None
         while self._apps_area.count():
             item = self._apps_area.takeAt(0)
             if item.widget():
@@ -973,6 +977,9 @@ class HomePage(QWidget):
 
         self._unassigned_expanded = True
         self._hidden_apps: set[str] = _load_hidden_apps()
+        # The row the "other applications" list is currently showing, so a
+        # poll that would draw the same one can leave it alone.
+        self._unassigned_sig: tuple | None = None
         self._unassigned_wrap.setVisible(False)
         self._style_unassigned()
         root.addWidget(self._unassigned_wrap)
@@ -1735,7 +1742,7 @@ class HomePage(QWidget):
         row that is already there, and left alone otherwise.
         """
         if not sinks:
-            if getattr(card, "_app_sig", None) != ():
+            if card._app_sig != ():
                 card.clear_apps()
                 card._app_sig = ()
             return
@@ -1756,13 +1763,13 @@ class HomePage(QWidget):
                          int(si.proplist.get("application.process.id", 0))))
 
         signature = tuple(rows)
-        if getattr(card, "_app_sig", None) == signature:
+        if card._app_sig == signature:
             return
-        card._app_sig = signature
 
         card.clear_apps()
         for app_name, si_index, pid in rows:
             card.add_app_tag(app_name, si_index, pid, bg_color=card._accent)
+        card._app_sig = signature
 
     def _style_unassigned(self) -> None:
         """Header styling, kept flat and quiet: this is a list, not an alert."""
@@ -1874,7 +1881,7 @@ class HomePage(QWidget):
         # whatever they are doing on top of it.
         signature = tuple((r["key"], r["label"], r["where"], r["si_index"], r["pid"])
                           for r in rows)
-        if signature == getattr(self, "_unassigned_sig", None):
+        if signature == self._unassigned_sig:
             return
         self._unassigned_sig = signature
 

--- a/tests/test_home_page_unassigned.py
+++ b/tests/test_home_page_unassigned.py
@@ -154,3 +154,71 @@ def test_show_hidden_restores_every_dismissed_app():
     with patch("arctis_sound_manager.gui.home_page._save_hidden_apps"):
         page._on_unhide_all()
     assert page._hidden_apps == set()
+
+
+# ── the 500 ms poll must not rebuild what has not changed ─────────────────────
+
+class _FakeCard:
+    _accent = "#333"
+
+    def __init__(self):
+        self.cleared = 0
+        self.tags: list[tuple] = []
+
+    def clear_apps(self):
+        self.cleared += 1
+        self.tags = []
+
+    def add_app_tag(self, name, si_index, pid, bg_color=""):
+        self.tags.append((name, si_index, pid))
+
+
+class _FakeSink:
+    def __init__(self, index, name):
+        self.index, self.name = index, name
+
+
+class _FakeSI:
+    def __init__(self, index, sink, app, pid=1):
+        self.index, self.sink = index, sink
+        self.proplist = {"application.name": app, "application.process.id": str(pid)}
+
+
+def test_an_unchanged_row_of_apps_is_left_alone():
+    """It ran twice a second, tearing down every tag widget and building it
+    again — while the user was dragging one of them to another channel."""
+    from arctis_sound_manager.gui.home_page import HomePage
+
+    card = _FakeCard()
+    sinks = [_FakeSink(1, "Arctis_Game")]
+    sis = [_FakeSI(10, 1, "GenshinImpact.exe")]
+
+    for _ in range(5):
+        HomePage._update_apps(HomePage, sis, sinks, card)
+
+    assert card.cleared == 1
+    assert card.tags == [("GenshinImpact.exe", 10, 1)]
+
+
+def test_a_changed_row_is_rebuilt():
+    from arctis_sound_manager.gui.home_page import HomePage
+
+    card = _FakeCard()
+    sinks = [_FakeSink(1, "Arctis_Game")]
+
+    HomePage._update_apps(HomePage, [_FakeSI(10, 1, "GenshinImpact.exe")], sinks, card)
+    HomePage._update_apps(HomePage, [_FakeSI(10, 1, "GenshinImpact.exe"),
+                                     _FakeSI(11, 1, "Discord")], sinks, card)
+
+    assert card.cleared == 2
+    assert [t[0] for t in card.tags] == ["GenshinImpact.exe", "Discord"]
+
+
+def test_a_channel_that_lost_its_sink_is_cleared_once():
+    from arctis_sound_manager.gui.home_page import HomePage
+
+    card = _FakeCard()
+    HomePage._update_apps(HomePage, [], [], card)
+    HomePage._update_apps(HomePage, [], [], card)
+
+    assert card.cleared == 1

--- a/tests/test_home_page_unassigned.py
+++ b/tests/test_home_page_unassigned.py
@@ -159,15 +159,19 @@ def test_show_hidden_restores_every_dismissed_app():
 # ── the 500 ms poll must not rebuild what has not changed ─────────────────────
 
 class _FakeCard:
+    """Stands in for AudioCard: the row, and the signature it remembers."""
+
     _accent = "#333"
 
     def __init__(self):
         self.cleared = 0
         self.tags: list[tuple] = []
+        self._app_sig = None
 
     def clear_apps(self):
         self.cleared += 1
         self.tags = []
+        self._app_sig = None
 
     def add_app_tag(self, name, si_index, pid, bg_color=""):
         self.tags.append((name, si_index, pid))


### PR DESCRIPTION
Dragging an application from one channel to another stutters, and sometimes stops responding while the pointer is down.

**To see it:** open the Home page with two or three applications playing, then drag one of their tags onto another channel. Seen on Plasma 6.5 / Wayland with PySide6 6.11, where the drag visibly fights the redraw; the cost is there on any desktop, it is just more or less visible.

The drag is competing with the page. `_poll_volumes` runs every 500 ms, and each pass calls `clear_apps()` on all four cards and builds a fresh `_AppTag` per application — and, since the "other applications" area landed, tears down and rebuilds every `_UnassignedRow` as well, each one a composite widget with its own buttons. That is two full teardowns and rebuilds a second, under a pointer that is dragging one of the widgets being destroyed.

The work is almost never needed: the list changes when somebody opens a game or moves a stream, not thirty times a minute. Both paths now compare the row they would draw against the row already on screen and return when they match.

Measured the poll before changing anything, so this is aimed at the right half:

| step | time |
|---|---|
| `pulsectl.Pulse()` connect | 6.9 ms |
| `sink_list()` | 1.1 ms |
| `sink_input_list()` | 1.8 ms |
| load + save overrides | 0.3 ms |

PulseAudio is not the cost. Widget churn is.

Three tests cover it: an unchanged row is left alone across repeated polls, a changed row is rebuilt, and a channel that lost its sink is cleared exactly once.

Suite: `1403 passed, 3 skipped`. The five `TestEnsurePhysicalOutputLinksRealGraph` failures on this machine need a live PipeWire graph and fail identically on unmodified `develop` (checked in a clean worktree).

Scope: `_update_apps` and `_refresh_unassigned` only. Nothing about *when* the poll runs, what it reads, or what it does with volumes changes — a card whose row differs by one application still rebuilds that row exactly as before.
