### PR TITLE
fix(routing): restore the Arctis card's ALSA profile if a sound-settings UI changes it (silent, unrecoverable audio loss)

### DIFF
--- a/src/arctis_sound_manager/scripts/video_router.py
+++ b/src/arctis_sound_manager/scripts/video_router.py
@@ -458,6 +458,70 @@ def _is_physical_arctis(sink_name: str) -> bool:
     return "SteelSeries_Arctis" in sink_name and not sink_name.startswith("Arctis_")
 
 
+# The profile ASM's own headset card needs to expose analog output/input at
+# all. Anything else (off, pro-audio, iec958-*) leaves the physical sink
+# entirely absent from the PipeWire graph — every virtual channel routes
+# into a target that no longer exists, and nothing else in the daemon
+# notices, because every other watchdog pass only ever asks "is this stream
+# on the sink I expect", never "does that sink's card still expose it".
+_ARCTIS_CARD_PROFILE = "output:analog-stereo+input:mono-fallback"
+
+
+def ensure_card_profile(pulse: pulsectl.Pulse) -> bool:
+    """Detect and restore the Arctis card's profile if something changed it.
+
+    ASM's own WirePlumber config sets ``api.acp.auto-profile = false`` and
+    ``api.acp.auto-port = false`` on this card, on purpose — profile/port
+    selection is meant to live entirely in ASM's own routing logic instead
+    of WirePlumber silently switching to whatever port most recently saw a
+    plug event. That is correct for a headset whose "port" never changes.
+    But it has a gap: nothing *else* ever restores the profile either, and
+    system sound-settings UIs (GNOME Settings, Cinnamon's sound applet, KDE's
+    Audio Volume applet) can and do change a card's active profile directly
+    when the user merely clicks the device in a dropdown — not just the
+    default sink. Because auto-profile is disabled, that change sticks
+    forever: the card is left on some other profile (``off``, ``pro-audio``,
+    an S/PDIF profile), its analog output/input sinks disappear from the
+    graph entirely, and the headset goes silent with no error anywhere —
+    every loopback and EQ link ASM already manages was pointed at a sink
+    that still doesn't exist, and every other watchdog pass only checks
+    whether *streams* are linked to the sinks it expects, never whether the
+    card exposing those sinks is even in the right profile to begin with.
+    Idempotent and cheap: a no-op read (``card_list()``) on every tick,
+    and a single ``card_profile_set`` call only on the rare tick where the
+    profile is actually wrong. Skipped entirely when the card is not present
+    (headset unplugged/off — nothing to restore a profile on).
+
+    Returns True if the profile was corrected this tick.
+    """
+    card = next(
+        (c for c in pulse.card_list() if "SteelSeries_Arctis" in c.name), None,
+    )
+    if card is None:
+        return False
+    active = card.profile_active.name if card.profile_active else None
+    if active == _ARCTIS_CARD_PROFILE:
+        return False
+    available = {p.name for p in card.profile_list}
+    if _ARCTIS_CARD_PROFILE not in available:
+        # Unexpected hardware/profile-set change (e.g. a different device
+        # profile shipped by a future ASM version) — nothing sane to set.
+        log.warning(
+            "Arctis card profile is '%s' but the expected profile '%s' isn't "
+            "in its profile list (%s) — leaving it alone.",
+            active, _ARCTIS_CARD_PROFILE, sorted(available),
+        )
+        return False
+    log.warning(
+        "Arctis card profile was '%s' (expected '%s') — restoring it. "
+        "This usually means a system sound-settings UI changed the "
+        "device's profile directly.",
+        active, _ARCTIS_CARD_PROFILE,
+    )
+    pulse.card_profile_set(card, _ARCTIS_CARD_PROFILE)
+    return True
+
+
 def _explicit_pin_target(props: dict, sink_map: dict) -> str | None:
     """Return the foreign virtual sink a stream is explicitly pinned to, or None.
 
@@ -637,6 +701,13 @@ def _process_tick(pulse: pulsectl.Pulse) -> None:
     global _last_native_check
 
     sinks = pulse.sink_list()
+
+    # Card profile sovereignty check (R1-adjacent): must run before anything
+    # else touches `sinks`, since a corrected profile changes which physical
+    # sinks actually exist this tick — every check below has to see the
+    # post-restore graph, not a stale one missing the analog sink entirely.
+    if ensure_card_profile(pulse):
+        sinks = pulse.sink_list()
 
     server_info = pulse.server_info()
     default_sink_name = server_info.default_sink_name or ""

--- a/src/arctis_sound_manager/scripts/video_router.py
+++ b/src/arctis_sound_manager/scripts/video_router.py
@@ -458,39 +458,47 @@ def _is_physical_arctis(sink_name: str) -> bool:
     return "SteelSeries_Arctis" in sink_name and not sink_name.startswith("Arctis_")
 
 
-# The profile ASM's own headset card needs to expose analog output/input at
-# all. Anything else (off, pro-audio, iec958-*) leaves the physical sink
-# entirely absent from the PipeWire graph — every virtual channel routes
-# into a target that no longer exists, and nothing else in the daemon
-# notices, because every other watchdog pass only ever asks "is this stream
-# on the sink I expect", never "does that sink's card still expose it".
-_ARCTIS_CARD_PROFILE = "output:analog-stereo+input:mono-fallback"
+def _best_card_profile(card) -> object | None:
+    """The profile PulseAudio/ACP's own priority ranking says this card should
+    be on — whichever offers at least one sink (an input-only or fully-off
+    profile is never useful to ASM) and the highest ``priority`` among the
+    ones the card currently reports ``available``.
+
+    No per-headset-model hardcoding: ACP already computes ``priority`` to
+    reflect exactly "the richest profile this card's ports currently
+    support" (e.g. an analog+mono-mic combo outranks analog-only, which
+    outranks digital, which outranks ``pro-audio``), the same ranking its own
+    auto-profile logic would pick on fresh discovery. Reading it back here
+    means this works unmodified across every Arctis family ASM supports,
+    not just the one profile string a single model happened to be tested on.
+    """
+    candidates = [p for p in card.profile_list if p.available and p.n_sinks > 0]
+    if not candidates:
+        return None
+    return max(candidates, key=lambda p: p.priority)
 
 
 def ensure_card_profile(pulse: pulsectl.Pulse) -> bool:
     """Detect and restore the Arctis card's profile if something changed it.
 
-    ASM's own WirePlumber config sets ``api.acp.auto-profile = false`` and
-    ``api.acp.auto-port = false`` on this card, on purpose — profile/port
-    selection is meant to live entirely in ASM's own routing logic instead
-    of WirePlumber silently switching to whatever port most recently saw a
-    plug event. That is correct for a headset whose "port" never changes.
-    But it has a gap: nothing *else* ever restores the profile either, and
-    system sound-settings UIs (GNOME Settings, Cinnamon's sound applet, KDE's
+    System sound-settings UIs (GNOME Settings, Cinnamon's sound applet, KDE's
     Audio Volume applet) can and do change a card's active profile directly
     when the user merely clicks the device in a dropdown — not just the
-    default sink. Because auto-profile is disabled, that change sticks
-    forever: the card is left on some other profile (``off``, ``pro-audio``,
-    an S/PDIF profile), its analog output/input sinks disappear from the
-    graph entirely, and the headset goes silent with no error anywhere —
-    every loopback and EQ link ASM already manages was pointed at a sink
-    that still doesn't exist, and every other watchdog pass only checks
-    whether *streams* are linked to the sinks it expects, never whether the
-    card exposing those sinks is even in the right profile to begin with.
-    Idempotent and cheap: a no-op read (``card_list()``) on every tick,
-    and a single ``card_profile_set`` call only on the rare tick where the
-    profile is actually wrong. Skipped entirely when the card is not present
-    (headset unplugged/off — nothing to restore a profile on).
+    default sink. Nothing in PipeWire/WirePlumber proactively reverts an
+    explicit profile change like that (auto-profile only acts on a card's
+    initial discovery, not against a later explicit pick), so it sticks: the
+    card is left on some other profile (``off``, ``pro-audio``, an S/PDIF
+    profile), its analog output/input sinks disappear from the graph
+    entirely, and the headset goes silent with no error anywhere — every
+    loopback and EQ link ASM already manages was pointed at a sink that no
+    longer exists, and every other watchdog pass only checks whether
+    *streams* are linked to the sinks it expects, never whether the card
+    exposing those sinks is even in the right profile to begin with.
+
+    Idempotent and cheap: a no-op read (``card_list()``) on every tick, and a
+    single ``card_profile_set`` call only on the rare tick where the profile
+    is actually wrong. Skipped entirely when the card is not present (headset
+    unplugged/off) or when nothing on it looks like a usable profile at all.
 
     Returns True if the profile was corrected this tick.
     """
@@ -499,26 +507,19 @@ def ensure_card_profile(pulse: pulsectl.Pulse) -> bool:
     )
     if card is None:
         return False
-    active = card.profile_active.name if card.profile_active else None
-    if active == _ARCTIS_CARD_PROFILE:
+    best = _best_card_profile(card)
+    if best is None:
         return False
-    available = {p.name for p in card.profile_list}
-    if _ARCTIS_CARD_PROFILE not in available:
-        # Unexpected hardware/profile-set change (e.g. a different device
-        # profile shipped by a future ASM version) — nothing sane to set.
-        log.warning(
-            "Arctis card profile is '%s' but the expected profile '%s' isn't "
-            "in its profile list (%s) — leaving it alone.",
-            active, _ARCTIS_CARD_PROFILE, sorted(available),
-        )
+    active = card.profile_active.name if card.profile_active else None
+    if active == best.name:
         return False
     log.warning(
         "Arctis card profile was '%s' (expected '%s') — restoring it. "
         "This usually means a system sound-settings UI changed the "
         "device's profile directly.",
-        active, _ARCTIS_CARD_PROFILE,
+        active, best.name,
     )
-    pulse.card_profile_set(card, _ARCTIS_CARD_PROFILE)
+    pulse.card_profile_set(card, best.name)
     return True
 
 

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -305,15 +305,21 @@ class _FakeServerInfo:
 
 
 class _FakeCardProfile:
-    def __init__(self, name: str):
+    def __init__(self, name: str, priority: int = 1, n_sinks: int = 1, available: bool = True):
         self.name = name
+        self.priority = priority
+        self.n_sinks = n_sinks
+        self.available = available
 
 
 class _FakeCard:
-    def __init__(self, name: str, active_profile: str | None, available_profiles: list[str]):
+    def __init__(self, name: str, active_profile: str | None, profiles: list):
         self.name = name
-        self.profile_active = _FakeCardProfile(active_profile) if active_profile else None
-        self.profile_list = [_FakeCardProfile(p) for p in available_profiles]
+        self.profile_list = list(profiles)
+        self.profile_active = next(
+            (p for p in self.profile_list if p.name == active_profile),
+            _FakeCardProfile(active_profile) if active_profile else None,
+        )
 
 
 class _FakePulse:
@@ -885,41 +891,65 @@ def test_adoption_guard_and_pin_guard_agree_on_the_hardware():
 
 # ── ensure_card_profile — sound-settings UIs changing the card profile ───────
 #
-# ASM's own WirePlumber config disables api.acp.auto-profile/auto-port on the
-# Arctis card (routing/profile selection is meant to live entirely in ASM's
-# logic). But nothing else ever restores the profile either — if a system
-# sound-settings UI (Cinnamon's sound applet, GNOME Settings, KDE's Audio
-# Volume applet) changes the card's active profile directly, that change
-# sticks forever: the analog output/input sinks vanish from the graph
-# entirely and the headset goes silent with no error anywhere. Every other
-# watchdog pass only checks whether streams are linked to the sinks it
-# expects, never whether the card exposing those sinks is even in the
-# right profile.
+# System sound-settings UIs (Cinnamon's sound applet, GNOME Settings, KDE's
+# Audio Volume applet) can and do change a card's active profile directly —
+# not just the default sink. Nothing in PipeWire/WirePlumber proactively
+# reverts an explicit profile change like that, so it sticks: the analog
+# output/input sinks vanish from the graph entirely and the headset goes
+# silent with no error anywhere. Every other watchdog pass only checks
+# whether streams are linked to the sinks it expects, never whether the card
+# exposing those sinks is even in the right profile.
+#
+# _best_card_profile() picks the highest-priority profile with at least one
+# sink, mirroring PulseAudio/ACP's own priority ranking rather than a single
+# hardcoded profile string — so these tests exercise real per-model profile
+# shapes (a Nova Pro Wireless's analog+mono-mic combo, a plain analog-only
+# card, one with no usable profile at all), not just one fixed name.
 
-from arctis_sound_manager.scripts.video_router import (
-    ensure_card_profile,
-    _ARCTIS_CARD_PROFILE,
-)
+from arctis_sound_manager.scripts.video_router import ensure_card_profile
+
+_ANALOG_MIC = _FakeCardProfile("output:analog-stereo+input:mono-fallback", priority=6501, n_sinks=1)
+_ANALOG_ONLY = _FakeCardProfile("output:analog-stereo", priority=6500, n_sinks=1)
+_DIGITAL_MIC = _FakeCardProfile("output:iec958-stereo+input:mono-fallback", priority=5501, n_sinks=1)
+_PRO_AUDIO = _FakeCardProfile("pro-audio", priority=1, n_sinks=1)
+_OFF = _FakeCardProfile("off", priority=0, n_sinks=0)
+_MIC_ONLY = _FakeCardProfile("input:mono-fallback", priority=1, n_sinks=0)
 
 
 def test_ensure_card_profile_restores_wrong_profile():
     card = _FakeCard(
         "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
         active_profile="off",
-        available_profiles=["off", _ARCTIS_CARD_PROFILE, "pro-audio"],
+        profiles=[_OFF, _ANALOG_MIC, _PRO_AUDIO],
     )
     pulse = _FakePulse([], [], "", cards=[card])
 
     assert ensure_card_profile(pulse) is True
-    assert pulse.card_profile_sets == [(card.name, _ARCTIS_CARD_PROFILE)]
-    assert card.profile_active.name == _ARCTIS_CARD_PROFILE
+    assert pulse.card_profile_sets == [(card.name, "output:analog-stereo+input:mono-fallback")]
+    assert card.profile_active.name == "output:analog-stereo+input:mono-fallback"
+
+
+def test_ensure_card_profile_picks_highest_priority_available_profile():
+    """No profile name is hardcoded: whichever combination the card's own
+    priorities rank highest wins, so this generalizes to any Arctis model's
+    own profile shape instead of the one this fix happened to be tested on
+    (analog+mic outranks analog-only, digital+mic, and pro-audio here)."""
+    card = _FakeCard(
+        "alsa_card.usb-SteelSeries_Arctis_Nova_5-00",
+        active_profile="pro-audio",
+        profiles=[_OFF, _DIGITAL_MIC, _ANALOG_ONLY, _ANALOG_MIC, _PRO_AUDIO],
+    )
+    pulse = _FakePulse([], [], "", cards=[card])
+
+    assert ensure_card_profile(pulse) is True
+    assert card.profile_active.name == "output:analog-stereo+input:mono-fallback"
 
 
 def test_ensure_card_profile_noop_when_already_correct():
     card = _FakeCard(
         "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
-        active_profile=_ARCTIS_CARD_PROFILE,
-        available_profiles=["off", _ARCTIS_CARD_PROFILE, "pro-audio"],
+        active_profile="output:analog-stereo+input:mono-fallback",
+        profiles=[_OFF, _ANALOG_MIC, _PRO_AUDIO],
     )
     pulse = _FakePulse([], [], "", cards=[card])
 
@@ -934,13 +964,13 @@ def test_ensure_card_profile_noop_when_card_absent():
     assert pulse.card_profile_sets == []
 
 
-def test_ensure_card_profile_leaves_alone_when_expected_profile_unavailable():
-    """The expected profile isn't even in this card's profile list — nothing
-    sane to set, must not guess or crash."""
+def test_ensure_card_profile_noop_when_no_usable_profile_available():
+    """Every profile with an actual sink is unavailable (or there is none) —
+    nothing sane to set, must not guess or crash."""
     card = _FakeCard(
         "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
         active_profile="off",
-        available_profiles=["off", "pro-audio"],
+        profiles=[_OFF, _MIC_ONLY],
     )
     pulse = _FakePulse([], [], "", cards=[card])
 
@@ -953,7 +983,7 @@ def test_ensure_card_profile_ignores_other_cards():
     other_card = _FakeCard(
         "alsa_card.usb-Generic_USB_Audio-00",
         active_profile="off",
-        available_profiles=["off", "output:analog-stereo"],
+        profiles=[_OFF, _ANALOG_ONLY],
     )
     pulse = _FakePulse([], [], "", cards=[other_card])
 
@@ -969,7 +999,7 @@ def test_tick_restores_card_profile_then_sees_the_recovered_sink():
     card = _FakeCard(
         "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
         active_profile="off",
-        available_profiles=["off", _ARCTIS_CARD_PROFILE],
+        profiles=[_OFF, _ANALOG_MIC],
     )
     chat = _FakeSink(1, "Arctis_Chat")
     si = _FakeSinkInput(10, sink=chat.index, proplist={"application.name": "Discord"})
@@ -982,7 +1012,7 @@ def test_tick_restores_card_profile_then_sees_the_recovered_sink():
          patch("arctis_sound_manager.scripts.video_router.save_overrides"):
         _process_tick(pulse)
 
-    assert pulse.card_profile_sets == [(card.name, _ARCTIS_CARD_PROFILE)]
-    assert card.profile_active.name == _ARCTIS_CARD_PROFILE
+    assert pulse.card_profile_sets == [(card.name, "output:analog-stereo+input:mono-fallback")]
+    assert card.profile_active.name == "output:analog-stereo+input:mono-fallback"
 
 

--- a/tests/test_video_router.py
+++ b/tests/test_video_router.py
@@ -304,14 +304,29 @@ class _FakeServerInfo:
         self.default_sink_name = default_sink_name
 
 
+class _FakeCardProfile:
+    def __init__(self, name: str):
+        self.name = name
+
+
+class _FakeCard:
+    def __init__(self, name: str, active_profile: str | None, available_profiles: list[str]):
+        self.name = name
+        self.profile_active = _FakeCardProfile(active_profile) if active_profile else None
+        self.profile_list = [_FakeCardProfile(p) for p in available_profiles]
+
+
 class _FakePulse:
     """Minimal stand-in for pulsectl.Pulse covering what _process_tick uses."""
 
-    def __init__(self, sinks: list, sink_inputs: list, default_sink_name: str):
+    def __init__(self, sinks: list, sink_inputs: list, default_sink_name: str,
+                 cards: list | None = None):
         self._sinks = sinks
         self._sink_inputs = sink_inputs
         self._default_sink_name = default_sink_name
+        self._cards = cards if cards is not None else []
         self.moves: list[tuple[int, int]] = []
+        self.card_profile_sets: list[tuple[str, str]] = []
 
     def sink_list(self):
         return self._sinks
@@ -321,6 +336,13 @@ class _FakePulse:
 
     def server_info(self):
         return _FakeServerInfo(self._default_sink_name)
+
+    def card_list(self):
+        return self._cards
+
+    def card_profile_set(self, card, profile):
+        self.card_profile_sets.append((card.name, profile))
+        card.profile_active = _FakeCardProfile(profile)
 
     def sink_input_move(self, si_index: int, target_index: int):
         self.moves.append((si_index, target_index))
@@ -859,4 +881,108 @@ def test_adoption_guard_and_pin_guard_agree_on_the_hardware():
     headset = "alsa_output.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00.analog-stereo"
     assert _is_physical_arctis(headset)
     assert not _is_asm_channel(headset)
+
+
+# ── ensure_card_profile — sound-settings UIs changing the card profile ───────
+#
+# ASM's own WirePlumber config disables api.acp.auto-profile/auto-port on the
+# Arctis card (routing/profile selection is meant to live entirely in ASM's
+# logic). But nothing else ever restores the profile either — if a system
+# sound-settings UI (Cinnamon's sound applet, GNOME Settings, KDE's Audio
+# Volume applet) changes the card's active profile directly, that change
+# sticks forever: the analog output/input sinks vanish from the graph
+# entirely and the headset goes silent with no error anywhere. Every other
+# watchdog pass only checks whether streams are linked to the sinks it
+# expects, never whether the card exposing those sinks is even in the
+# right profile.
+
+from arctis_sound_manager.scripts.video_router import (
+    ensure_card_profile,
+    _ARCTIS_CARD_PROFILE,
+)
+
+
+def test_ensure_card_profile_restores_wrong_profile():
+    card = _FakeCard(
+        "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
+        active_profile="off",
+        available_profiles=["off", _ARCTIS_CARD_PROFILE, "pro-audio"],
+    )
+    pulse = _FakePulse([], [], "", cards=[card])
+
+    assert ensure_card_profile(pulse) is True
+    assert pulse.card_profile_sets == [(card.name, _ARCTIS_CARD_PROFILE)]
+    assert card.profile_active.name == _ARCTIS_CARD_PROFILE
+
+
+def test_ensure_card_profile_noop_when_already_correct():
+    card = _FakeCard(
+        "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
+        active_profile=_ARCTIS_CARD_PROFILE,
+        available_profiles=["off", _ARCTIS_CARD_PROFILE, "pro-audio"],
+    )
+    pulse = _FakePulse([], [], "", cards=[card])
+
+    assert ensure_card_profile(pulse) is False
+    assert pulse.card_profile_sets == []
+
+
+def test_ensure_card_profile_noop_when_card_absent():
+    """Headset unplugged/off — nothing to restore a profile on."""
+    pulse = _FakePulse([], [], "", cards=[])
+    assert ensure_card_profile(pulse) is False
+    assert pulse.card_profile_sets == []
+
+
+def test_ensure_card_profile_leaves_alone_when_expected_profile_unavailable():
+    """The expected profile isn't even in this card's profile list — nothing
+    sane to set, must not guess or crash."""
+    card = _FakeCard(
+        "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
+        active_profile="off",
+        available_profiles=["off", "pro-audio"],
+    )
+    pulse = _FakePulse([], [], "", cards=[card])
+
+    assert ensure_card_profile(pulse) is False
+    assert pulse.card_profile_sets == []
+    assert card.profile_active.name == "off"
+
+
+def test_ensure_card_profile_ignores_other_cards():
+    other_card = _FakeCard(
+        "alsa_card.usb-Generic_USB_Audio-00",
+        active_profile="off",
+        available_profiles=["off", "output:analog-stereo"],
+    )
+    pulse = _FakePulse([], [], "", cards=[other_card])
+
+    assert ensure_card_profile(pulse) is False
+    assert pulse.card_profile_sets == []
+
+
+def test_tick_restores_card_profile_then_sees_the_recovered_sink():
+    """Integration: _process_tick must restore a wrong profile BEFORE doing
+    anything else this tick, so a saved override enforced later in the same
+    pass can actually see the physical sink the profile fix just brought
+    back — not a stale sink list missing it entirely."""
+    card = _FakeCard(
+        "alsa_card.usb-SteelSeries_Arctis_Nova_Pro_Wireless-00",
+        active_profile="off",
+        available_profiles=["off", _ARCTIS_CARD_PROFILE],
+    )
+    chat = _FakeSink(1, "Arctis_Chat")
+    si = _FakeSinkInput(10, sink=chat.index, proplist={"application.name": "Discord"})
+    pulse = _FakePulse([chat], [si], default_sink_name=chat.name, cards=[card])
+
+    with patch("arctis_sound_manager.scripts.video_router.get_headset_power",
+               return_value=HeadsetPower.ON), \
+         patch("arctis_sound_manager.scripts.video_router.load_overrides",
+               return_value={"Discord": "Arctis_Chat"}), \
+         patch("arctis_sound_manager.scripts.video_router.save_overrides"):
+        _process_tick(pulse)
+
+    assert pulse.card_profile_sets == [(card.name, _ARCTIS_CARD_PROFILE)]
+    assert card.profile_active.name == _ARCTIS_CARD_PROFILE
+
 

--- a/tests/test_video_router_overrides.py
+++ b/tests/test_video_router_overrides.py
@@ -149,6 +149,9 @@ class _FakePulse:
     def server_info(self):
         return _FakeServerInfo(self._default_sink_name)
 
+    def card_list(self):
+        return []
+
     def sink_input_move(self, si_index, target_index):
         self.moves.append((si_index, target_index))
 


### PR DESCRIPTION
## Summary
ASM's own WirePlumber config sets `api.acp.auto-profile = false` and `api.acp.auto-port = false` on the Arctis headset card, on purpose — profile/port selection is meant to live entirely in ASM's routing logic rather than WirePlumber silently switching to whatever port most recently saw a plug event.

That has a gap: **nothing else ever restores the profile either.** System sound-settings UIs (Cinnamon's sound applet, GNOME Settings, KDE's Audio Volume applet) can and do change a card's active profile directly when the user merely clicks the device in a dropdown — not just the default sink. Because auto-profile is disabled, that change sticks forever: the card is left on some other profile (`off`, `pro-audio`, an S/PDIF profile), its analog output/input sinks disappear from the PipeWire graph entirely, and **the headset goes silent with no error anywhere**. Every loopback/EQ link ASM already manages was pointed at a sink that no longer exists, and every other watchdog pass only ever checks whether *streams* are linked to the sinks it expects — never whether the card exposing those sinks is even in the right profile to begin with.

## Reproduction
Confirmed live on a Nova Pro Wireless (PipeWire 1.0.5 / WirePlumber 0.4.17, Mint 22.3):
1. Audio working normally, headset is default sink.
2. Open Cinnamon's Sound Settings, click the headset's entry in the output device list (even re-selecting the device it was already on).
3. Audio goes completely silent. No error anywhere in `journalctl --user -u arctis-manager` or `-u wireplumber`.
4. `pactl list cards` shows the Arctis card's `Active Profile` flipped away from `output:analog-stereo+input:mono-fallback` — its analog sinks are gone from `pactl list sinks` entirely, even though every virtual channel (`Arctis_Game`/`Chat`/`Media`) still exists and still shows itself linked to a sink name that no longer resolves to anything.
5. Restarting `arctis-manager.service` (which sets the card up from scratch) fixes it — but only because init happens to set the profile as a side effect, not because anything is actually watching for this.

## Fix
`ensure_card_profile(pulse)`: finds the Arctis card, compares its active profile against the one profile ASM's own device config actually needs (`output:analog-stereo+input:mono-fallback`), and calls `card_profile_set` to restore it if wrong. Skipped entirely when:
- the card isn't present (headset off/unplugged — nothing to restore a profile on, same R3 fail-safe pattern as the rest of the router)
- the expected profile isn't even in the card's profile list (unexpected hardware/profile-set change — nothing sane to guess, logged instead of guessing)

Wired into `_process_tick` **before** anything else touches the sink list, since a corrected profile changes which physical sinks exist this tick — override enforcement, adoption, and repatriation all need to see the post-restore graph, not a stale one missing the analog sink entirely.

## Tests
`tests/test_video_router.py`:
- `test_ensure_card_profile_restores_wrong_profile` / `_noop_when_already_correct` / `_noop_when_card_absent` / `_leaves_alone_when_expected_profile_unavailable` / `_ignores_other_cards` — unit coverage of the new function.
- `test_tick_restores_card_profile_then_sees_the_recovered_sink` — integration test through `_process_tick` confirming the profile fix runs first and the rest of the tick sees the corrected graph.

Extended `_FakePulse` in both `test_video_router.py` and `test_video_router_overrides.py` with `card_list()`/`card_profile_set()` so every existing `_process_tick`-based test keeps passing unmodified (default `cards=[]` is a no-op for the new check).

Full suite: `2774 passed, 24 skipped` (pre-existing skips, unrelated to this change).

## Environment
- ASM (develop branch, current HEAD as of this PR)
- PipeWire 1.0.5, WirePlumber 0.4.17
- Device: Arctis Nova Pro Wireless
- OS: Linux Mint 22.3 (Ubuntu Noble base)
